### PR TITLE
order exchange logic

### DIFF
--- a/src/main/java/com/example/demo/base/exception/NotOwnerException.java
+++ b/src/main/java/com/example/demo/base/exception/NotOwnerException.java
@@ -1,0 +1,15 @@
+package com.example.demo.base.exception;
+
+public class NotOwnerException extends RuntimeException {
+    public NotOwnerException() {
+    }
+
+    public NotOwnerException(String message) {
+        super(message);
+    }
+
+    public NotOwnerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/com/example/demo/base/initdata/CustomInitData.java
+++ b/src/main/java/com/example/demo/base/initdata/CustomInitData.java
@@ -35,7 +35,10 @@ public class CustomInitData {
                                 .count(10)
                         .price(15000)
                         .name("product1").build());
-
+                Product product2 = productRepository.save(Product.builder()
+                        .count(100)
+                        .price(10000)
+                        .name("product2").build());
 
                 String encode = passwordEncoder.encode("1111");
                 Member user = Member.builder()
@@ -54,18 +57,16 @@ public class CustomInitData {
                 orderRepository.save(order);
 
                 OrderDetail orderDetail1 = OrderDetail.builder()
-                        .product(product1)
                         .count(2)
                         .build();
                 orderDetail1.addOrder(order,product1);
                 orderDetailRepository.save(orderDetail1);
 
                 OrderDetail orderDetail2 = OrderDetail.builder()
-                        .product(product1)
                         .status(OrderItemStatus.PLACED)
                         .count(2)
                         .build();
-                orderDetail2.addOrder(order,product1);
+                orderDetail2.addOrder(order,product2);
                 orderDetailRepository.save(orderDetail2);
 
                 Member admin = Member.builder()

--- a/src/main/java/com/example/demo/base/initdata/CustomInitData.java
+++ b/src/main/java/com/example/demo/base/initdata/CustomInitData.java
@@ -5,6 +5,7 @@ import com.example.demo.boundedContext.member.entity.Member;
 import com.example.demo.boundedContext.member.repository.MemberRepository;
 import com.example.demo.boundedContext.order.entity.Order;
 import com.example.demo.boundedContext.order.entity.OrderDetail;
+import com.example.demo.boundedContext.order.entity.OrderItemStatus;
 import com.example.demo.boundedContext.order.repository.OrderDetailRepository;
 import com.example.demo.boundedContext.order.repository.OrderRepository;
 import com.example.demo.boundedContext.product.entity.Product;
@@ -61,6 +62,7 @@ public class CustomInitData {
 
                 OrderDetail orderDetail2 = OrderDetail.builder()
                         .product(product1)
+                        .status(OrderItemStatus.PLACED)
                         .count(2)
                         .build();
                 orderDetail2.addOrder(order,product1);

--- a/src/main/java/com/example/demo/boundedContext/order/controller/OrderController.java
+++ b/src/main/java/com/example/demo/boundedContext/order/controller/OrderController.java
@@ -34,12 +34,23 @@ public class OrderController {
 
     @GetMapping("/result")
     public String resultPage(Model model) {
+        ResponseData<LastOrderDto> responseData = findLastCompleteOrderOne();
+        model.addAttribute("order", responseData.getContent());
+        return "order/result";
+    }
+
+    @GetMapping("/orderStatus")
+    public String orderStatus(Model model) {
+        ResponseData<LastOrderDto> responseData = findLastCompleteOrderOne();
+        model.addAttribute("order", responseData.getContent());
+        return "product/orderHistory";
+
+    }
+
+    private ResponseData<LastOrderDto> findLastCompleteOrderOne() {
         String username = rq.getUsername();
         Member member = memberService.findByUsername(username);
-        ResponseData<LastOrderDto> responseData = orderService.findCompleteLastOrder(member.getId());
-        model.addAttribute("order", responseData.getContent());
-
-        return "order/result";
+        return orderService.findCompleteLastOrder(member.getId());
     }
 
 }

--- a/src/main/java/com/example/demo/boundedContext/order/controller/OrderController.java
+++ b/src/main/java/com/example/demo/boundedContext/order/controller/OrderController.java
@@ -53,13 +53,13 @@ public class OrderController {
 
     @GetMapping("/exchange/{id}")
     public String exchangeGet(Model model,
-            @PathVariable(name = "id") Long orderDetailId) {
+                              @PathVariable(name = "id") Long orderId,
+                              @RequestParam Long orderItemId) {
 
-        OrderExchangeDto dto = orderDetailService.findOrderDetailById(orderDetailId, null, rq.getMemberId());
+        OrderExchangeDto dto = orderDetailService.findOrderDetailById(orderId, orderItemId, rq.getMemberId());
 
-        model.addAttribute("orderDetail",dto);
+        model.addAttribute("orderDetail", dto);
         return "order/exchange";
-
     }
 
     @PostMapping("/exchange/{id}")
@@ -74,7 +74,7 @@ public class OrderController {
         if (!dto.isReturn()) {
             orderDetailService.exchange(dto);
         } else {
-            orderDetailService.returnProduct(orderId,dto);
+            orderDetailService.returnProduct(orderId, dto);
         }
 
         return "redirect:/order/orderInfo";

--- a/src/main/java/com/example/demo/boundedContext/order/controller/TossController.java
+++ b/src/main/java/com/example/demo/boundedContext/order/controller/TossController.java
@@ -1,5 +1,6 @@
 package com.example.demo.boundedContext.order.controller;
 
+import com.example.demo.base.exception.OrderException;
 import com.example.demo.boundedContext.order.dto.OrderRequest;
 import com.example.demo.boundedContext.order.infra.TossPaymentInfra;
 import com.example.demo.boundedContext.order.service.OrderService;
@@ -11,7 +12,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.client.RestTemplate;
 
 @RequiredArgsConstructor
 @RequestMapping("/toss")
@@ -20,6 +20,7 @@ public class TossController {
 
 
     private final OrderService orderService;
+    private final TossPaymentInfra tossPaymentService;
     private final Rq rq;
 
 
@@ -30,10 +31,12 @@ public class TossController {
     public String orderByToss(Model model,OrderRequest orderRequest) throws Exception {
 
         try {
-            orderService.verifyAndRequestToss(orderRequest,rq.getMemberId());
+            orderService.verifyRequest(orderRequest,rq.getMemberId());
+            tossPaymentService.requestPermitToss(orderRequest);
             return "redirect:/order/result";
-        } catch (Exception e) {
-            model.addAttribute("fail","실패");
+
+        } catch (OrderException e) {
+            model.addAttribute("fail",e.getMessage());
             return "order/orderPage";
         }
     }

--- a/src/main/java/com/example/demo/boundedContext/order/dto/LastOrderDto.java
+++ b/src/main/java/com/example/demo/boundedContext/order/dto/LastOrderDto.java
@@ -33,7 +33,12 @@ public class LastOrderDto {
         this.orderName = order.getOrderName();
         this.uuid =order.getUuid();
         order.getOrderDetailList()
+                .stream().filter(LastOrderDto::isEqualStatus)
                 .forEach(i -> orderDetails.add(new OrderItemDto(i)));
+    }
+
+    private static boolean isEqualStatus(OrderDetail i) {
+        return i.getStatus().equals(OrderItemStatus.PENDING);
     }
 
     @Getter

--- a/src/main/java/com/example/demo/boundedContext/order/dto/LastOrderDto.java
+++ b/src/main/java/com/example/demo/boundedContext/order/dto/LastOrderDto.java
@@ -31,13 +31,14 @@ public class LastOrderDto {
         this.orderName = order.getOrderName();
         this.uuid =order.getUuid();
         order.getOrderDetailList()
-                .forEach(i -> orderDetails.add(new OrderItemDto(i.getProduct().getName(),i.getCount(),i.getAmount())));
+                .forEach(i -> orderDetails.add(new OrderItemDto(i.getId(),i.getProduct().getName(),i.getCount(),i.getAmount())));
     }
 
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     static class OrderItemDto {
+        private Long orderItemId;
         private String productName;
         private int count;
         private int amount;
@@ -48,5 +49,9 @@ public class LastOrderDto {
             amount = orderDetail.getAmount();
 
         }
+    }
+
+    public boolean isEmpty() {
+        return orderId == null;
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/dto/LastOrderDto.java
+++ b/src/main/java/com/example/demo/boundedContext/order/dto/LastOrderDto.java
@@ -2,6 +2,7 @@ package com.example.demo.boundedContext.order.dto;
 
 import com.example.demo.boundedContext.order.entity.Order;
 import com.example.demo.boundedContext.order.entity.OrderDetail;
+import com.example.demo.boundedContext.order.entity.OrderItemStatus;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ public class LastOrderDto {
     private Long totalAmount;
     private String orderName;
     private String uuid;
+    private OrderItemStatus status;
 
     private List<OrderItemDto> orderDetails = new ArrayList<>();
 
@@ -31,7 +33,7 @@ public class LastOrderDto {
         this.orderName = order.getOrderName();
         this.uuid =order.getUuid();
         order.getOrderDetailList()
-                .forEach(i -> orderDetails.add(new OrderItemDto(i.getId(),i.getProduct().getName(),i.getCount(),i.getAmount())));
+                .forEach(i -> orderDetails.add(new OrderItemDto(i)));
     }
 
     @Getter
@@ -42,12 +44,14 @@ public class LastOrderDto {
         private String productName;
         private int count;
         private int amount;
+        private OrderItemStatus status;
 
         public OrderItemDto(OrderDetail orderDetail) {
-            productName = orderDetail.getProduct().getName();
-            count = orderDetail.getCount();
-            amount = orderDetail.getAmount();
-
+            this.orderItemId = orderDetail.getId();
+            this.productName = orderDetail.getProduct().getName();
+            this.count = orderDetail.getCount();
+            this.amount = orderDetail.getAmount();
+            this.status = orderDetail.getStatus();
         }
     }
 

--- a/src/main/java/com/example/demo/boundedContext/order/dto/OrderExchangeDto.java
+++ b/src/main/java/com/example/demo/boundedContext/order/dto/OrderExchangeDto.java
@@ -1,0 +1,24 @@
+package com.example.demo.boundedContext.order.dto;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class OrderExchangeDto {
+    private Long orderItemId;
+    private String productName;
+    private int count;
+    private int amount;
+
+    public OrderExchangeDto(Long orderItemId, String productName, int count, int price) {
+        this.orderItemId = orderItemId;
+        this.productName = productName;
+        this.count = count;
+        this.amount = price * count;
+    }
+}

--- a/src/main/java/com/example/demo/boundedContext/order/dto/OrderExchangeDto.java
+++ b/src/main/java/com/example/demo/boundedContext/order/dto/OrderExchangeDto.java
@@ -2,6 +2,7 @@ package com.example.demo.boundedContext.order.dto;
 
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
@@ -15,7 +16,7 @@ import static com.example.demo.boundedContext.order.entity.OrderItemStatus.*;
 @Getter
 public class OrderExchangeDto {
 
-    @NotBlank
+    @NotNull
     private Long orderItemId;
 
     private String productName;

--- a/src/main/java/com/example/demo/boundedContext/order/dto/OrderExchangeDto.java
+++ b/src/main/java/com/example/demo/boundedContext/order/dto/OrderExchangeDto.java
@@ -1,24 +1,45 @@
 package com.example.demo.boundedContext.order.dto;
 
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+import org.hibernate.validator.constraints.Length;
+
+import static com.example.demo.boundedContext.order.entity.OrderItemStatus.*;
 
 @ToString
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
 @Getter
 public class OrderExchangeDto {
+
+    @NotBlank
     private Long orderItemId;
+
     private String productName;
+
     private int count;
-    private int amount;
+
+    private int totalPrice;
+
+    @Length(min = 5,max = 100)
+    @NotBlank(message = "최소 5자 이상의 이유를 적어주세요")
+    private String reason;
+
+
+    @Pattern(regexp = "^(EXCHANGE|RETURN)$",message = "잘못된 요청입니다.")
+    private String exchange;
 
     public OrderExchangeDto(Long orderItemId, String productName, int count, int price) {
         this.orderItemId = orderItemId;
         this.productName = productName;
         this.count = count;
-        this.amount = price * count;
+        this.totalPrice = price * count;
+    }
+
+    public boolean isReturn() {
+        return exchange.equals(RETURN.name());
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/entity/Order.java
+++ b/src/main/java/com/example/demo/boundedContext/order/entity/Order.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 @Table(name = "Orders",indexes = {@Index(name = "toss_uuid",columnList = "uuid")})
 public class Order extends BaseEntity {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
     private String req;
 
@@ -54,6 +54,8 @@ public class Order extends BaseEntity {
 
     public void addOrderDetail(OrderDetail orderDetail) {
         orderDetailList.add(orderDetail);
+        this.totalPrice += orderDetail.getCount();
+        this.itemCount += orderDetail.getAmount();
     }
 
     public void canOrder(OrderRequest orderRequest) {
@@ -77,13 +79,5 @@ public class Order extends BaseEntity {
         for (OrderDetail item : orderDetailList) {
             item.orderComplete();
         }
-    }
-
-    public void addPrice(int amount) {
-        this.totalPrice += amount;
-    }
-
-    public void addCount(int count) {
-        this.itemCount += count;
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/entity/Order.java
+++ b/src/main/java/com/example/demo/boundedContext/order/entity/Order.java
@@ -74,6 +74,9 @@ public class Order extends BaseEntity {
 
     public void updateComplete() {
         status = OrderStatus.COMPLETE;
+        for (OrderDetail item : orderDetailList) {
+            item.orderComplete();
+        }
     }
 
     public void addPrice(int amount) {

--- a/src/main/java/com/example/demo/boundedContext/order/entity/Order.java
+++ b/src/main/java/com/example/demo/boundedContext/order/entity/Order.java
@@ -1,5 +1,6 @@
 package com.example.demo.boundedContext.order.entity;
 
+import com.example.demo.base.exception.OrderException;
 import com.example.demo.boundedContext.member.entity.Address;
 import com.example.demo.boundedContext.member.entity.Member;
 import com.example.demo.base.entity.BaseEntity;
@@ -55,12 +56,19 @@ public class Order extends BaseEntity {
         orderDetailList.add(orderDetail);
     }
 
-    public boolean canOrder(OrderRequest orderRequest) {
-        return !isPaid() && orderRequest.getAmount().equals(totalPrice);
+    public void canOrder(OrderRequest orderRequest) {
+        isPaid();
+        isEqualAmount(orderRequest.getAmount());
     }
 
-    public boolean isPaid() {
-        return status.equals(OrderStatus.COMPLETE);
+    public void isPaid() {
+         if (!status.equals(OrderStatus.BEFORE))
+             throw new OrderException("이미 주문 완료한 상품입니다.");
+    }
+
+    public void isEqualAmount(Long totalAmount) {
+        if (!totalAmount.equals(totalPrice))
+            throw new OrderException("총합이 맞지 않습니다.");
     }
 
 

--- a/src/main/java/com/example/demo/boundedContext/order/entity/OrderDetail.java
+++ b/src/main/java/com/example/demo/boundedContext/order/entity/OrderDetail.java
@@ -47,6 +47,5 @@ public class OrderDetail extends BaseEntity {
 
     public void orderComplete() {
         this.status = OrderItemStatus.PLACED;
-        product.updateProductCount(count);
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/entity/OrderDetail.java
+++ b/src/main/java/com/example/demo/boundedContext/order/entity/OrderDetail.java
@@ -23,6 +23,10 @@ public class OrderDetail extends BaseEntity {
     @ManyToOne
     private Order order;
 
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private OrderItemStatus status = OrderItemStatus.PENDING;
+
     private int count;
 
     public void addOrder(Order order,Product product) {
@@ -39,5 +43,10 @@ public class OrderDetail extends BaseEntity {
 
     public int getAmount() {
         return product.getPrice() * count;
+    }
+
+    public void orderComplete() {
+        this.status = OrderItemStatus.PLACED;
+        product.updateProductCount(count);
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/entity/OrderDetail.java
+++ b/src/main/java/com/example/demo/boundedContext/order/entity/OrderDetail.java
@@ -47,11 +47,7 @@ public class OrderDetail extends BaseEntity {
     }
 
     public void orderComplete() {
-        if (status.equals(PENDING)) {
-            updateStatus(PLACED);
-        } else {
-            throw new OrderException("Item이 주문 가능한 상태가 아닙니다.");
-        }
+        updateStatus(PLACED);
     }
 
     public void updateStatus(OrderItemStatus status) {

--- a/src/main/java/com/example/demo/boundedContext/order/entity/OrderDetail.java
+++ b/src/main/java/com/example/demo/boundedContext/order/entity/OrderDetail.java
@@ -10,6 +10,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
+import static com.example.demo.boundedContext.order.entity.OrderItemStatus.*;
+
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,7 +28,7 @@ public class OrderDetail extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Builder.Default
-    private OrderItemStatus status = OrderItemStatus.PENDING;
+    private OrderItemStatus status = PENDING;
 
     private int count;
 
@@ -45,10 +47,18 @@ public class OrderDetail extends BaseEntity {
     }
 
     public void orderComplete() {
-        if (status.equals(OrderItemStatus.PENDING)) {
-            this.status = OrderItemStatus.PLACED;
+        if (status.equals(PENDING)) {
+            updateStatus(PLACED);
         } else {
             throw new OrderException("Item이 주문 가능한 상태가 아닙니다.");
         }
+    }
+
+    public void updateStatus(OrderItemStatus status) {
+        this.status = status;
+    }
+
+    public void decreaseCount(int count) {
+        this.count -= count;
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/entity/OrderDetail.java
+++ b/src/main/java/com/example/demo/boundedContext/order/entity/OrderDetail.java
@@ -2,6 +2,7 @@ package com.example.demo.boundedContext.order.entity;
 
 import com.example.demo.base.entity.BaseEntity;
 import com.example.demo.base.exception.NotEnoughProductCount;
+import com.example.demo.base.exception.OrderException;
 import com.example.demo.boundedContext.product.entity.Product;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 
@@ -16,11 +17,11 @@ import lombok.experimental.SuperBuilder;
 @Entity
 public class OrderDetail extends BaseEntity {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Product product;
 
     @JsonBackReference
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Order order;
 
     @Enumerated(EnumType.STRING)
@@ -35,8 +36,6 @@ public class OrderDetail extends BaseEntity {
         this.product = product;
 
         order.addOrderDetail(this);
-        order.addCount(count);
-        order.addPrice(getAmount());
         this.order = order;
     }
 
@@ -46,6 +45,10 @@ public class OrderDetail extends BaseEntity {
     }
 
     public void orderComplete() {
-        this.status = OrderItemStatus.PLACED;
+        if (status.equals(OrderItemStatus.PENDING)) {
+            this.status = OrderItemStatus.PLACED;
+        } else {
+            throw new OrderException("Item이 주문 가능한 상태가 아닙니다.");
+        }
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/entity/OrderItemStatus.java
+++ b/src/main/java/com/example/demo/boundedContext/order/entity/OrderItemStatus.java
@@ -1,0 +1,5 @@
+package com.example.demo.boundedContext.order.entity;
+
+public enum OrderItemStatus {
+    PENDING, PLACED, SHIPPED, DELIVERED, CANCELLED
+}

--- a/src/main/java/com/example/demo/boundedContext/order/entity/OrderItemStatus.java
+++ b/src/main/java/com/example/demo/boundedContext/order/entity/OrderItemStatus.java
@@ -1,5 +1,5 @@
 package com.example.demo.boundedContext.order.entity;
 
 public enum OrderItemStatus {
-    PENDING, PLACED, SHIPPED, DELIVERED, CANCELLED, EXCHANGED
+    PENDING, PLACED, SHIPPED, DELIVERED, CANCELLED, EXCHANGE, RETURN
 }

--- a/src/main/java/com/example/demo/boundedContext/order/entity/OrderItemStatus.java
+++ b/src/main/java/com/example/demo/boundedContext/order/entity/OrderItemStatus.java
@@ -1,5 +1,5 @@
 package com.example.demo.boundedContext.order.entity;
 
 public enum OrderItemStatus {
-    PENDING, PLACED, SHIPPED, DELIVERED, CANCELLED
+    PENDING, PLACED, SHIPPED, DELIVERED, CANCELLED, EXCHANGED
 }

--- a/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepository.java
@@ -1,9 +1,10 @@
 package com.example.demo.boundedContext.order.repository;
 
-import com.example.demo.boundedContext.order.entity.OrderDetail;
+import com.example.demo.boundedContext.order.dto.OrderExchangeDto;
 
 import java.util.Optional;
 
 public interface CustomOrderDetailRepository {
-    Optional<OrderDetail> findByIdWithMemberId(Long orderId, Long orderItemId,Long memberId);
+
+    Optional<OrderExchangeDto> findByIdWithMemberId(Long orderId, Long orderItemId, Long memberId);
 }

--- a/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepository.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 
 public interface CustomOrderDetailRepository {
 
-    Optional<OrderExchangeDto> findByIdWithMemberId(Long orderId, Long orderItemId, Long memberId);
+    Optional<OrderExchangeDto> findByOrderIdAndMemberId(Long orderId, Long orderItemId, Long memberId);
 }

--- a/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.boundedContext.order.repository;
+
+import com.example.demo.boundedContext.order.entity.OrderDetail;
+
+import java.util.Optional;
+
+public interface CustomOrderDetailRepository {
+    Optional<OrderDetail> findByIdWithMemberId(Long orderId, Long orderItemId,Long memberId);
+}

--- a/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepositoryImpl.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.example.demo.boundedContext.order.repository;
+
+import com.example.demo.boundedContext.order.dto.OrderExchangeDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.example.demo.boundedContext.order.entity.QOrder.order;
+import static com.example.demo.boundedContext.order.entity.QOrderDetail.orderDetail;
+import static com.example.demo.boundedContext.product.entity.QProduct.product;
+
+@RequiredArgsConstructor
+@Transactional
+@Repository
+public class CustomOrderDetailRepositoryImpl implements  CustomOrderDetailRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<OrderExchangeDto> findByIdWithMemberId(Long orderId, Long orderItemId, Long memberId) {
+
+        OrderExchangeDto orderExchangeDto = jpaQueryFactory.select(Projections.constructor(
+                        OrderExchangeDto.class, orderDetail.id, product.name, orderDetail.count, product.price
+                ))
+                .from(order)
+                .join(order.orderDetailList, orderDetail)
+                .join(orderDetail.product, product)
+                .where(equalOrderId(orderId), equalMember(memberId), equalOrderItemId(orderItemId))
+                .fetchOne();
+
+        return Optional.ofNullable(orderExchangeDto);
+    }
+
+    private static BooleanExpression equalOrderId(Long orderId) {
+        return order.id.eq(orderId);
+    }
+
+    private BooleanExpression equalOrderItemId(Long orderItemId) {
+        return orderDetail.id.eq(orderItemId);
+    }
+
+    private BooleanExpression equalMember(Long memberId) {
+        return order.member.id.eq(memberId);
+    }
+}

--- a/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepositoryImpl.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+import static com.example.demo.boundedContext.order.entity.OrderItemStatus.*;
 import static com.example.demo.boundedContext.order.entity.QOrder.order;
 import static com.example.demo.boundedContext.order.entity.QOrderDetail.orderDetail;
 import static com.example.demo.boundedContext.product.entity.QProduct.product;
@@ -34,10 +35,14 @@ public class CustomOrderDetailRepositoryImpl implements CustomOrderDetailReposit
                 .where(equalOrderId(orderId),
                         equalMember(memberId),
                         equalOrderItemId(orderItemId),
-                        orderDetail.status.eq(OrderItemStatus.PLACED))
+                        isBeforeDeliver())
                 .fetchOne();
 
         return Optional.ofNullable(orderExchangeDto);
+    }
+
+    private static BooleanExpression isBeforeDeliver() {
+        return orderDetail.status.eq(PLACED).or(orderDetail.status.eq(PENDING));
     }
 
     private static BooleanExpression equalOrderId(Long orderId) {

--- a/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderRepository.java
@@ -1,0 +1,4 @@
+package com.example.demo.boundedContext.order.repository;
+
+public interface CustomOrderRepository  {
+}

--- a/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderRepositoryImpl.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderRepositoryImpl.java
@@ -1,0 +1,6 @@
+package com.example.demo.boundedContext.order.repository;
+
+public class CustomOrderRepositoryImpl implements CustomOrderRepository {
+
+
+}

--- a/src/main/java/com/example/demo/boundedContext/order/repository/OrderDetailRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/OrderDetailRepository.java
@@ -3,5 +3,5 @@ package com.example.demo.boundedContext.order.repository;
 import com.example.demo.boundedContext.order.entity.OrderDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderDetailRepository extends JpaRepository<OrderDetail,Long> {
+public interface OrderDetailRepository extends JpaRepository<OrderDetail,Long>, CustomOrderDetailRepository {
 }

--- a/src/main/java/com/example/demo/boundedContext/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/OrderRepository.java
@@ -9,10 +9,10 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface OrderRepository extends JpaRepository<Order,Long> {
+public interface OrderRepository extends JpaRepository<Order,Long>,CustomOrderRepository {
 
-    @Query("select o from Order o join o.member m where m.id = :id and" +
-            " o.status = 'BEFORE' order by o.id desc limit 1")
+    @Query("select o from Order o join o.orderDetailList ol join o.member m where m.id = :id and" +
+            " o.status = 'BEFORE'  order by o.id desc limit 1")
     Optional<Order> findLastOrder(@Param("id") Long id);
 
     @Query("select o from Order o join o.member m where m.id = :id and" +

--- a/src/main/java/com/example/demo/boundedContext/order/service/OrderDetailService.java
+++ b/src/main/java/com/example/demo/boundedContext/order/service/OrderDetailService.java
@@ -2,11 +2,17 @@ package com.example.demo.boundedContext.order.service;
 
 import com.example.demo.base.exception.DataNotFoundException;
 import com.example.demo.boundedContext.order.dto.OrderExchangeDto;
+import com.example.demo.boundedContext.order.entity.Order;
 import com.example.demo.boundedContext.order.entity.OrderDetail;
 import com.example.demo.boundedContext.order.repository.OrderDetailRepository;
+import com.example.demo.boundedContext.order.repository.OrderRepository;
+import com.example.demo.boundedContext.product.entity.Product;
+import com.example.demo.boundedContext.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.demo.boundedContext.order.entity.OrderItemStatus.EXCHANGE;
 
 
 @RequiredArgsConstructor
@@ -15,10 +21,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderDetailService {
 
     private final OrderDetailRepository orderDetailRepository;
+    private final OrderRepository orderRepository;
+    private final ProductRepository productRepository;
 
     public OrderExchangeDto findOrderDetailById(Long orderId, Long orderItemId, Long memberId) {
 
-        return orderDetailRepository.findByIdWithMemberId(orderId, orderItemId, memberId)
+        return orderDetailRepository.findByOrderIdAndMemberId(orderId, orderItemId, memberId)
                 .orElseThrow(() -> new DataNotFoundException("존재하지 않는 데이터입니다"));
+    }
+
+    public void exchange(OrderExchangeDto dto) {
+        OrderDetail orderDetail = orderDetailRepository.findById(dto.getOrderItemId()).orElseThrow();
+        orderDetail.updateStatus(EXCHANGE);
+    }
+
+    public void returnProduct(Long orderId, OrderExchangeDto dto) {
+        Order order = orderRepository.findById(orderId).orElseThrow();
+        order.returnProduct(dto);
+        Product product = productRepository.findByName(dto.getProductName())
+                .orElseThrow(() -> new DataNotFoundException("존재하지 않는 데이터입니다"));
+        product.addCount(dto.getCount());
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/service/OrderDetailService.java
+++ b/src/main/java/com/example/demo/boundedContext/order/service/OrderDetailService.java
@@ -1,0 +1,23 @@
+package com.example.demo.boundedContext.order.service;
+
+import com.example.demo.base.exception.DataNotFoundException;
+import com.example.demo.boundedContext.order.entity.OrderDetail;
+import com.example.demo.boundedContext.order.repository.OrderDetailRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class OrderDetailService {
+
+    private final OrderDetailRepository orderDetailRepository;
+
+    public OrderDetail findOrderDetailById(Long orderId,Long orderItemId, Long memberId) {
+
+        return orderDetailRepository.findByIdWithMemberId(orderId,orderItemId,memberId)
+                .orElseThrow(() -> new DataNotFoundException("존재하지 않는 데이터입니다"));
+    }
+}

--- a/src/main/java/com/example/demo/boundedContext/order/service/OrderDetailService.java
+++ b/src/main/java/com/example/demo/boundedContext/order/service/OrderDetailService.java
@@ -1,6 +1,7 @@
 package com.example.demo.boundedContext.order.service;
 
 import com.example.demo.base.exception.DataNotFoundException;
+import com.example.demo.boundedContext.order.dto.OrderExchangeDto;
 import com.example.demo.boundedContext.order.entity.OrderDetail;
 import com.example.demo.boundedContext.order.repository.OrderDetailRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,9 +16,9 @@ public class OrderDetailService {
 
     private final OrderDetailRepository orderDetailRepository;
 
-    public OrderDetail findOrderDetailById(Long orderId,Long orderItemId, Long memberId) {
+    public OrderExchangeDto findOrderDetailById(Long orderId, Long orderItemId, Long memberId) {
 
-        return orderDetailRepository.findByIdWithMemberId(orderId,orderItemId,memberId)
+        return orderDetailRepository.findByIdWithMemberId(orderId, orderItemId, memberId)
                 .orElseThrow(() -> new DataNotFoundException("존재하지 않는 데이터입니다"));
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/service/OrderService.java
+++ b/src/main/java/com/example/demo/boundedContext/order/service/OrderService.java
@@ -61,12 +61,6 @@ public class OrderService {
     public void orderPayComplete(OrderRequest orderRequest) {
         Order order = findByOrderRequest(orderRequest);
 
-        order.getOrderDetailList().forEach(i -> {
-            Long id = i.getProduct().getId();
-            Product product = productRepository.findByIdWithLock(id).orElseThrow();
-            product.updateProductCount(i.getCount());
-        });
-
         order.updateComplete();
     }
 

--- a/src/main/java/com/example/demo/boundedContext/order/service/OrderService.java
+++ b/src/main/java/com/example/demo/boundedContext/order/service/OrderService.java
@@ -36,8 +36,7 @@ public class OrderService {
         if (!isOrderOwner(memberId, order))
             throw new OrderException("해당 주문에 권한 없음");
 
-        if (!order.canOrder(orderRequest))
-            throw new OrderException("총합 계산이 맞지 않습니다.");
+        order.canOrder(orderRequest);
 
         orderPayComplete(orderRequest);
         tossPaymentInfra.requestPermitToss(orderRequest);
@@ -48,15 +47,15 @@ public class OrderService {
         Optional<Order> optionalOrder = orderRepository.findByUuid(orderRequest.getOrderId());
 
         if (optionalOrder.isEmpty())
-            throw new OrderException("status update 에러 발생");
-
+            throw new OrderException("존재하지 않는 주문입니다");
 
         return optionalOrder.get();
     }
 
-    private static boolean isOrderOwner(Long memberId, Order order) {
+    private boolean isOrderOwner(Long memberId, Order order) {
         return order.getMember().getId().equals(memberId);
     }
+
 
     @Transactional
     public void orderPayComplete(OrderRequest orderRequest) {

--- a/src/main/java/com/example/demo/boundedContext/product/controller/ProductController.java
+++ b/src/main/java/com/example/demo/boundedContext/product/controller/ProductController.java
@@ -1,0 +1,15 @@
+package com.example.demo.boundedContext.product.controller;
+
+import com.example.demo.boundedContext.order.service.OrderDetailService;
+import com.example.demo.util.rq.Rq;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@RequestMapping("/product")
+@Controller
+public class ProductController {
+
+
+}

--- a/src/main/java/com/example/demo/boundedContext/product/entity/Product.java
+++ b/src/main/java/com/example/demo/boundedContext/product/entity/Product.java
@@ -41,4 +41,8 @@ public class Product extends BaseEntity {
     public boolean isEnoughCount(int count) {
         return this.count - count >= 0;
     }
+
+    public void addCount(int count) {
+        this.count +=count;
+    }
 }

--- a/src/main/java/com/example/demo/boundedContext/product/entity/Product.java
+++ b/src/main/java/com/example/demo/boundedContext/product/entity/Product.java
@@ -26,6 +26,9 @@ public class Product extends BaseEntity {
     private int salePrice;
     private int count;
 
+    @Version
+    private Long version;
+
     public void updateProductCount(int purchase) {
         if (count - purchase < 0)
             throw new OrderException("재고가 부족합니다");

--- a/src/main/java/com/example/demo/boundedContext/product/entity/Product.java
+++ b/src/main/java/com/example/demo/boundedContext/product/entity/Product.java
@@ -1,10 +1,13 @@
 package com.example.demo.boundedContext.product.entity;
 
+import com.example.demo.base.entity.BaseEntity;
 import com.example.demo.base.exception.OrderException;
 import com.example.demo.boundedContext.category.entity.Category;
-import com.example.demo.base.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
@@ -16,7 +19,7 @@ import org.hibernate.annotations.SQLDelete;
 @Entity
 public class Product extends BaseEntity {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Category category;
     private String name;
 
@@ -30,8 +33,12 @@ public class Product extends BaseEntity {
     private Long version;
 
     public void updateProductCount(int purchase) {
-        if (count - purchase < 0)
+        if (!isEnoughCount(purchase))
             throw new OrderException("재고가 부족합니다");
         this.count -= purchase;
+    }
+
+    public boolean isEnoughCount(int count) {
+        return this.count - count >= 0;
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/product/event/ProductDecreaseEvent.java
+++ b/src/main/java/com/example/demo/boundedContext/product/event/ProductDecreaseEvent.java
@@ -1,0 +1,11 @@
+package com.example.demo.boundedContext.product.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ProductDecreaseEvent {
+    private final Long productId;
+    private final int count;
+}

--- a/src/main/java/com/example/demo/boundedContext/product/event/ProductEvent.java
+++ b/src/main/java/com/example/demo/boundedContext/product/event/ProductEvent.java
@@ -1,0 +1,27 @@
+package com.example.demo.boundedContext.product.event;
+
+import com.example.demo.boundedContext.product.entity.Product;
+import com.example.demo.boundedContext.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Component
+@RequiredArgsConstructor
+public class ProductEvent {
+
+    private final ProductService productService;
+
+
+    @Transactional
+    @EventListener
+    public void decreaseEvent(ProductDecreaseEvent event) {
+        Long productId = event.getProductId();
+        int count = event.getCount();
+
+        Product product = productService.findById(productId);
+        product.updateProductCount(count);
+    }
+}

--- a/src/main/java/com/example/demo/boundedContext/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/product/repository/ProductRepository.java
@@ -3,5 +3,8 @@ package com.example.demo.boundedContext.product.repository;
 import com.example.demo.boundedContext.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    Optional<Product> findByName(String name);
 }

--- a/src/main/java/com/example/demo/boundedContext/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/product/repository/ProductRepository.java
@@ -1,27 +1,7 @@
 package com.example.demo.boundedContext.product.repository;
 
 import com.example.demo.boundedContext.product.entity.Product;
-import jakarta.persistence.LockModeType;
-import jakarta.persistence.QueryHint;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
-import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
-
-
-    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "30000")})
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select p from Product p where p.id = :id")
-    Optional<Product> findByIdWithLock(@Param("id") Long id);
-    Optional<Product> findById(Long id);
-    Page<Product> findAll(Pageable pageable);
-
-
 }

--- a/src/main/java/com/example/demo/boundedContext/product/service/ProductService.java
+++ b/src/main/java/com/example/demo/boundedContext/product/service/ProductService.java
@@ -1,0 +1,22 @@
+package com.example.demo.boundedContext.product.service;
+
+import com.example.demo.base.exception.DataNotFoundException;
+import com.example.demo.boundedContext.product.entity.Product;
+import com.example.demo.boundedContext.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    public Product findById(Long id) {
+        return productRepository.findById(id).orElseThrow(() -> new DataNotFoundException("존재하지 않는 Product입니다."));
+    }
+
+
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -10,6 +10,10 @@ spring:
       ddl-auto: create
     generate-ddl: true
 
+  sql:
+    init:
+      mode: never
+
 
 
 

--- a/src/main/resources/templates/order/exchange.html
+++ b/src/main/resources/templates/order/exchange.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html layout:decorate="~{common/layout.html}" xmlns="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<main layout:fragment="main" class="min-h-screen flex justify-center items-center">
+    <form method="post" id="orderForm" th:action
+          class="w-full p-6 max-w-sm border rounded-[20px] h-4/6"
+          th:object="${orderDetail}">
+        <div class="flex justify-center">
+            <figure class="md:flex md:items-center mb-6">
+                <img src="/images/stock/photo-1606107557195-0e29a4b5b4aa.jpg" alt="Shoes" class="rounded-xl"/>
+            </figure>
+        </div>
+        <div class="md:flex md:items-center mb-6">
+
+            <div class="md:w-1/3">
+                <label class="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" for="inline-full-name">
+                    물품 이름
+                </label>
+            </div>
+            <div class="md:w-2/3">
+                <input th:name="${orderDetail.productName}" th:value="${orderDetail.productName}"
+                       class="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
+                       id="inline-full-name" type="text" disabled>
+            </div>
+        </div>
+        <div class="md:flex md:items-center mb-6">
+            <div class="md:w-1/3">
+                <label class="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" for="inline-password">
+                    개수
+                </label>
+            </div>
+            <div class="md:w-2/3">
+                <select th:field="*{count}"
+                        class="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500">
+                    <option th:each="i : ${#numbers.sequence(1, orderDetail.count)}" th:value="${i}" th:text="${i}"></option>
+                </select>
+            </div>
+        </div>
+        <div class="md:flex md:items-center mb-6">
+            <div class="md:w-1/3">
+                <label class="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" for="inline-password">
+                    금액
+                </label>
+            </div>
+            <div class="md:w-2/3">
+                <input th:name="${orderDetail.getTotalPrice}" th:value="${orderDetail.getTotalPrice}"
+                       class="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
+                       id="inline-password" disabled>
+            </div>
+        </div>
+        <div class="md:flex md:items-center mb-6">
+            <div class="md:w-1/3">
+                <label class="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" for="inline-password">
+                    사유
+                </label>
+            </div>
+            <div class="md:w-2/3">
+                <input  th:field="*{reason}"
+                       class="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
+                           id="inline-password" type="text">
+            </div>
+        </div>
+        <div class="md:flex md:items-center">
+            <div class="md:w-1/3"></div>
+            <div class="md:w-2/3">
+                <button class="shadow bg-gradient-to-r from-indigo-200 via-red-200 to-yellow-100
+                 hover:from-yellow-100 via-yellow-300 to-yellow-500 focus:shadow-outline focus:outline-none text-black font-bold py-2 px-4 rounded"
+                  data-action="EXCHANGE" onclick="submitForm(this)"  >
+                    교환하기
+                </button>
+            </div>
+            <div class="md:w-2/3">
+                <button class="shadow bg-gradient-to-r from-gray-200 via-gray-400 to-gray-600
+                 hover:from-gray-700 via-gray-900 to-black focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded"
+                    data-action="RETURN"  onclick="submitForm(this)"  >
+                    반품하기
+                </button>
+            </div>
+        </div>
+    </form>
+    <script th:inline="javascript">
+        function submitForm(button) {
+            const form = document.getElementById('orderForm');
+            const exchangeInput = document.createElement('input');
+            const itemId = document.createElement('input');
+            const actionInput = button.getAttribute('data-action')
+            const orderItemId =/*[[${orderDetail.orderItemId}]]*/ null;
+
+            exchangeInput.setAttribute('type', 'hidden');
+            exchangeInput.setAttribute('name', 'exchange');
+            exchangeInput.setAttribute('value', actionInput);
+
+            itemId.setAttribute('type', 'hidden');
+            itemId.setAttribute('name', 'orderItemId');
+            itemId.setAttribute('value', orderItemId);
+
+            form.appendChild(exchangeInput);
+            form.appendChild(itemId);
+            form.submit();
+        }
+    </script>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/order/orderInfo.html
+++ b/src/main/resources/templates/order/orderInfo.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html layout:decorate="~{common/layout.html}" xmlns="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>교환 반품</title>
+</head>
+<body>
+<main class="min-w-full" layout:fragment="main">
+
+    <div class="flex flex-col border rounded-[20px] justify-content align-items mx-auto w-2/3 ">
+
+        <div class="h-screen flex flex-col justify-center align-items gap-3 mt-3" th:if="${!order.isEmpty()}">
+            <h1 class="text-center text-blue-800 text-3xl underline font-bold">현재 나의 주문 내역</h1>
+            <table class="text-center border">
+                <tr>
+                    <th colspan="2" class="text-xl bg-gray-400 font-bold">주문내역</th>
+                </tr>
+                <tr>
+                    <td class="text-xl border  py-2 font-bold">주문번호</td>
+                    <td class="text-bold text-xl border py-2  rounded-[20px] px-[10px] " id="orderId"
+                        th:text="|${order.orderId}|"></td>
+                </tr>
+                <tr>
+                    <td class="text-xl border  py-2 font-bold">주문 날짜</td>
+                    <td class="text-bold text-xl border py-2  rounded-[20px] px-[10px] " id="orderDate"
+                        th:text="${#temporals.format(order.modifyDate, 'yyyy-MM-dd')}"></td>
+                </tr>
+                <tr>
+                    <td class="text-xl border  py-2 font-bold">총 주문 금액</td>
+                    <td class="text-bold text-xl border py-2  rounded-[20px] px-[10px] " id="totalAmount"
+                        th:text="|${order.getTotalAmount()}원|"></td>
+                </tr>
+            </table>
+            <table class="text-center border">
+                <thead>
+                <tr>
+                    <th class="text-xl font-bold">번호</th>
+                    <th class="text-xl font-bold">상품명</th>
+                    <th class="text-xl font-bold">개수</th>
+                    <th class="text-xl font-bold">금액</th>
+                    <th class="text-xl font-bold">--</th>
+                </tr>
+                </thead>
+                <tbody id="detailsRow" class="hidden">
+                <tr class="gap-3 cursor-pointer border" th:each="orderItem , i : ${order.orderDetails}">
+                    <td class="text-xl" id="num" th:text="${i.index+1}">번호</td>
+                    <td class="text-xl" id="name" th:text="${orderItem.productName}">이름</td>
+                    <td class="text-xl" id="count" th:text="${orderItem.count}">개수</td>
+                    <td class="text-xl" id="total" th:text="|${orderItem.amount}원|">금액</td>
+                    <td class="text-xl" id="exchange">
+                        <div class="flex flex-col gap-3 m-2">">
+                            <button type="button" class="btn btn-outline btn-info"
+                                    data-action="exchange" th:data-orderItemId="${orderItem.orderItemId}"
+                                    th:disabled="${orderItem.status != 'PENDING' and orderItem.status != 'PLACED'}"
+                                    onclick="requestExchange(this)">
+                                교환 및 반품
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <script th:inline="javascript">
+        function requestExchange(e) {
+            const action = e.dataset.action;
+            const orderItemId = e.dataset.orderItemId;
+            let check = prompt(`정말 ${action}하시겠습니까?`);
+
+            if (!check) {
+                return;
+            }
+
+            const orderId = /*[[${order.id}]]*/ null;
+            const formData = new FormData();
+            formData.append("orderItemId", orderItemId);
+            formData.append("action",action);
+
+            fetch("/product/exchange/"+orderId, {
+                method: "POST",
+                body: formData,
+                cache: "no-cache"
+            }).then(response => {
+
+            })
+                .catch(e => {
+                    alert("잠시 후에 다시 시도해주세요");
+                    location.reload();
+                });
+        }
+
+    </script>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/order/orderInfo.html
+++ b/src/main/resources/templates/order/orderInfo.html
@@ -50,8 +50,9 @@
                     <td class="text-xl" id="exchange">
                         <div class="flex flex-col gap-3 m-2">">
                             <button type="button" class="btn btn-outline btn-info"
-                                    data-action="exchange" th:data-orderItemId="${orderItem.orderItemId}"
-                                    th:disabled="${orderItem.status != 'PENDING' and orderItem.status != 'PLACED'}"
+                                    th:data-orderId="${order.orderId}"
+                                    th:data-orderItemId="${orderItem.orderItemId}"
+                                    th:disabled="${orderItem.status != 'PENDING' or orderItem.status != 'PLACED'}"
                                     onclick="requestExchange(this)">
                                 교환 및 반품
                             </button>
@@ -64,30 +65,11 @@
     </div>
     <script th:inline="javascript">
         function requestExchange(e) {
-            const action = e.dataset.action;
-            const orderItemId = e.dataset.orderItemId;
-            let check = prompt(`정말 ${action}하시겠습니까?`);
+            const orderId = button.dataset.orderId;
+            const orderItemId = button.dataset.orderItemId;
 
-            if (!check) {
-                return;
-            }
+            window.location.href = `/exchange/${orderId}?orderItemId=${orderItemId}`;
 
-            const orderId = /*[[${order.id}]]*/ null;
-            const formData = new FormData();
-            formData.append("orderItemId", orderItemId);
-            formData.append("action",action);
-
-            fetch("/product/exchange/"+orderId, {
-                method: "POST",
-                body: formData,
-                cache: "no-cache"
-            }).then(response => {
-
-            })
-                .catch(e => {
-                    alert("잠시 후에 다시 시도해주세요");
-                    location.reload();
-                });
         }
 
     </script>

--- a/src/test/java/com/example/demo/ProjectShopApplicationTests.java
+++ b/src/test/java/com/example/demo/ProjectShopApplicationTests.java
@@ -1,9 +1,10 @@
 package com.example.demo;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ProjectShopApplicationTests {
     @Test

--- a/src/test/java/com/example/demo/boundedContext/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/example/demo/boundedContext/order/repository/OrderRepositoryTest.java
@@ -4,9 +4,13 @@ import com.example.demo.base.Role;
 import com.example.demo.boundedContext.member.entity.Member;
 import com.example.demo.boundedContext.member.repository.MemberRepository;
 import com.example.demo.boundedContext.order.dto.LastOrderDto;
+import com.example.demo.boundedContext.order.dto.OrderExchangeDto;
 import com.example.demo.boundedContext.order.entity.Order;
+import com.example.demo.boundedContext.order.entity.OrderDetail;
 import com.example.demo.boundedContext.order.entity.OrderStatus;
 import com.example.demo.boundedContext.order.service.OrderService;
+import com.example.demo.boundedContext.product.entity.Product;
+import com.example.demo.boundedContext.product.repository.ProductRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +31,8 @@ class OrderRepositoryTest {
 
     @Autowired
     OrderRepository orderRepository;
+    @Autowired
+    OrderDetailRepository orderDetailRepository;
 
     @Autowired
     OrderService orderService;
@@ -35,6 +41,8 @@ class OrderRepositoryTest {
     PasswordEncoder passwordEncoder;
 
     Member member;
+    @Autowired
+    private ProductRepository productRepository;
 
     @BeforeEach
     void setUp() {
@@ -65,5 +73,30 @@ class OrderRepositoryTest {
         LastOrderDto order = orderService.findLastOrderById(member.getId()).getContent();
         Assertions.assertThat(order.getOrderId()).isEqualTo(order2.getId());
     }
+
+    @Test
+    @DisplayName("findByIdWithMemberId test")
+    void t3() {
+
+        Member member = memberRepository.save(Member.builder().build());
+
+        Order order = orderRepository.save(Order.builder().status(OrderStatus.COMPLETE)
+                .member(member).build());
+
+        Product product = productRepository.save(Product.builder().name("product").count(100).price(1000).build());
+
+        OrderDetail orderDetail = OrderDetail.builder().count(10).build();
+        orderDetail.addOrder(order,product);
+        orderDetailRepository.save(orderDetail);
+
+        OrderExchangeDto dto = orderDetailRepository.findByIdWithMemberId(order.getId(), orderDetail.getId(), member.getId()).orElseThrow();
+
+        Assertions.assertThat(dto.getAmount()).isEqualTo(product.getPrice() * orderDetail.getCount());
+        Assertions.assertThat(dto.getOrderItemId()).isEqualTo(orderDetail.getId());
+        Assertions.assertThat(dto.getProductName()).isEqualTo("product");
+
+
+    }
+
 
 }

--- a/src/test/java/com/example/demo/boundedContext/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/example/demo/boundedContext/order/repository/OrderRepositoryTest.java
@@ -89,9 +89,9 @@ class OrderRepositoryTest {
         orderDetail.addOrder(order,product);
         orderDetailRepository.save(orderDetail);
 
-        OrderExchangeDto dto = orderDetailRepository.findByIdWithMemberId(order.getId(), orderDetail.getId(), member.getId()).orElseThrow();
+        OrderExchangeDto dto = orderDetailRepository.findByOrderIdAndMemberId(order.getId(), orderDetail.getId(), member.getId()).orElseThrow();
 
-        Assertions.assertThat(dto.getAmount()).isEqualTo(product.getPrice() * orderDetail.getCount());
+        Assertions.assertThat(dto.getTotalPrice()).isEqualTo(product.getPrice() * orderDetail.getCount());
         Assertions.assertThat(dto.getOrderItemId()).isEqualTo(orderDetail.getId());
         Assertions.assertThat(dto.getProductName()).isEqualTo("product");
 

--- a/src/test/java/com/example/demo/boundedContext/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/demo/boundedContext/order/service/OrderServiceTest.java
@@ -86,7 +86,6 @@ class OrderServiceTest {
         OrderRequest orderRequest = new OrderRequest("1__2__3", order.getUuid(), 8000L);
         Mockito.when(tossPaymentInfra.requestPermitToss(orderRequest)).thenReturn(ResponseEntity.ok("good"));
 
-        orderService.verifyAndRequestToss(orderRequest, member.getId());
         assertThat(order.getTotalPrice()).isEqualTo(8000L);
 
     }
@@ -97,9 +96,8 @@ class OrderServiceTest {
 
         OrderRequest orderRequest = new OrderRequest("1__2__3", order.getUuid(), 1000L);
 
-        Mockito.when(tossPaymentInfra.requestPermitToss(orderRequest)).thenReturn(ResponseEntity.ok("good"));
 
-        Assertions.assertThatThrownBy(() -> orderService.verifyAndRequestToss(orderRequest, member.getId()))
+        Assertions.assertThatThrownBy(() -> orderService.verifyRequest(orderRequest, member.getId()))
                 .isInstanceOf(OrderException.class);
     }
 
@@ -109,9 +107,8 @@ class OrderServiceTest {
 
         OrderRequest orderRequest = new OrderRequest("1__2__3", order.getUuid(), 2000L);
 
-        Mockito.when(tossPaymentInfra.requestPermitToss(orderRequest)).thenReturn(ResponseEntity.ok("good"));
 
-        assertThatThrownBy(() -> orderService.verifyAndRequestToss(orderRequest, member.getId()))
+        assertThatThrownBy(() -> orderService.verifyRequest(orderRequest, member.getId()))
                 .isInstanceOf(OrderException.class);
     }
 
@@ -120,9 +117,8 @@ class OrderServiceTest {
     void noAuthorityForOrder() {
         OrderRequest orderRequest = new OrderRequest("1__2__3", "12123", 1000L);
 
-        Mockito.when(tossPaymentInfra.requestPermitToss(orderRequest)).thenReturn(ResponseEntity.ok("good"));
 
-        assertThatThrownBy(() -> orderService.verifyAndRequestToss(orderRequest, member.getId()))
+        assertThatThrownBy(() -> orderService.verifyRequest(orderRequest, member.getId()))
                 .isInstanceOf(OrderException.class);
     }
 
@@ -139,9 +135,7 @@ class OrderServiceTest {
 
         OrderRequest orderRequest = new OrderRequest("1__2__3", save.getUuid(), product.getPrice() * 1200L);
 
-        Mockito.when(tossPaymentInfra.requestPermitToss(orderRequest)).thenReturn(ResponseEntity.ok("good"));
-
-        assertThatThrownBy(() -> orderService.verifyAndRequestToss(orderRequest, member.getId()))
+        assertThatThrownBy(() -> orderService.verifyRequest(orderRequest, member.getId()))
                 .isInstanceOf(OrderException.class).hasMessageContaining("재고가 부족합니다");
     }
 }

--- a/src/test/java/com/example/demo/boundedContext/product/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/example/demo/boundedContext/product/repository/ProductRepositoryTest.java
@@ -1,11 +1,13 @@
 package com.example.demo.boundedContext.product.repository;
 
 import com.example.demo.boundedContext.product.entity.Product;
+import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,11 +19,14 @@ class ProductRepositoryTest {
     @Autowired
     ProductRepository productRepository;
 
+    @Autowired
+    EntityManager em;
+
     @Test
     @DisplayName("updateProductCount test")
     void t1() {
         Product save = productRepository.save(Product.builder().name("product").price(1000).count(5).build());
-        Product product = productRepository.findByIdWithLock(save.getId()).orElseThrow();
+        Product product = productRepository.findById(save.getId()).orElseThrow();
 
         Assertions.assertThat(product.getPrice()).isEqualTo(1000);
         Assertions.assertThat(product.getName()).isEqualTo("product");
@@ -29,6 +34,23 @@ class ProductRepositoryTest {
         product.updateProductCount(3);
 
         Assertions.assertThat(product.getCount()).isEqualTo(2);
+    }
+
+    @Rollback(value = false)
+    @Test
+    @DisplayName("product version test")
+    void t2() {
+        Product save = productRepository.save(Product.builder().name("product").price(1000).count(100).build());
+
+        Product product = productRepository.findById(save.getId()).orElseThrow();
+        Long version = product.getVersion();
+
+        product.updateProductCount(3);
+        em.flush();
+        em.clear();
+
+        Assertions.assertThat(version+1).isEqualTo(product.getVersion());
+
     }
 
 }


### PR DESCRIPTION
# order exchange logic

## 1. order exchange logic

- order exchange logic입니다.
- 페이지 구현은 완성했으나 다른 문제점이 없는지는 더 봐야 할 것 같습니다.

## 2. fetch type lazy로 변경

- fetch type을 lazy로 변경하였습니다.

### 추가한 점

- orderItemStatus와 OrderStatus는 각각 OrdeDetail과 Order를 위한 enum입니다.
- toss payment의 경우 결합도를 낮추기 위해 이벤트를 사용하였습니다.
- 비관적 lock에서 낙관적 lock으로 변경하였습니다.
- 현재 컨트롤러에서 Dto로 반환하도록 하고 있습니다.(entity 반환시 문제가 발생해서 dto로 필요한 것만 받도록 하였습니다.)
- 테스트 코드가 없는 상황입니다. -> 아직 로직이 완성되지 않은 상황이므로 더 보완해서 올리겠습니다.