### PR TITLE
product 상세 페이지 구현

### DIFF
--- a/src/main/java/com/example/demo/ProjectShopApplication.java
+++ b/src/main/java/com/example/demo/ProjectShopApplication.java
@@ -7,8 +7,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableAsync
-@EnableScheduling
+
 @EnableCaching
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/example/demo/base/exception/CustomControllerAdvice.java
+++ b/src/main/java/com/example/demo/base/exception/CustomControllerAdvice.java
@@ -1,7 +1,9 @@
 package com.example.demo.base.exception;
 
+import com.example.demo.util.rq.Rq;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.task.TaskRejectedException;
 import org.springframework.http.HttpStatus;
@@ -10,8 +12,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Slf4j
+@RequiredArgsConstructor
 @ControllerAdvice
 public class CustomControllerAdvice {
+
+    private final Rq rq;
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(TaskRejectedException.class)
@@ -22,5 +27,21 @@ public class CustomControllerAdvice {
         log.info("TaskRejectedException 발생 | [사용자 IP] ={}", request.getRemoteAddr());
 
         return String.format("redirect:%s",referer);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(OrderException.class)
+    public String badOrderRequest( Exception e) {
+        return rq.historyBack(e.getMessage());
+    }
+
+
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(NotOwnerException.class)
+    public String notOwnerException(HttpServletRequest request, Exception e) {
+        log.error("NotOwnerException 발생", e);
+        log.info("NotOwnerException 발생 | [사용자 IP] ={}", request.getRemoteAddr());
+        return rq.historyBack(e.getMessage());
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/member/controller/MbtiTestController.java
+++ b/src/main/java/com/example/demo/boundedContext/member/controller/MbtiTestController.java
@@ -62,12 +62,12 @@ public class MbtiTestController {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Authorization", "Bearer " + chatGptkey);
 
-        ArrayList<MbtiTestController.Message> list = new ArrayList<>();
-        list.add(new MbtiTestController.Message("user", message));
+        ArrayList<Message> list = new ArrayList<>();
+        list.add(new Message("user", message));
 
-        MbtiTestController.Body param = new MbtiTestController.Body("gpt-3.5-turbo", list);
+        Body param = new Body("gpt-3.5-turbo", list);
 
-        RequestEntity<MbtiTestController.Body> httpEntity = new RequestEntity<>(param, httpHeaders, HttpMethod.POST, uri);
+        RequestEntity<Body> httpEntity = new RequestEntity<>(param, httpHeaders, HttpMethod.POST, uri);
 
         ResponseEntity<String> responseEntity = restTemplate.exchange(httpEntity, String.class);
 
@@ -110,7 +110,7 @@ public class MbtiTestController {
     @Data
     static class Body {
         String model;
-        List<MbtiTestController.Message> messages;
+        List<Message> messages;
     }
 
     @AllArgsConstructor

--- a/src/main/java/com/example/demo/boundedContext/order/controller/OrderController.java
+++ b/src/main/java/com/example/demo/boundedContext/order/controller/OrderController.java
@@ -70,9 +70,9 @@ public class OrderController {
         }
 
         if (!dto.isReturn()) {
-            orderDetailService.exchange(dto);
+            orderDetailService.exchange(dto,rq.getMemberId());
         } else {
-            orderDetailService.returnProduct(orderId, dto);
+            orderDetailService.returnProduct(orderId, dto,rq.getMemberId());
         }
 
         return rq.redirectWithMsg("/order/orderInfo","요청이 성공하였습니다.");

--- a/src/main/java/com/example/demo/boundedContext/order/controller/TossController.java
+++ b/src/main/java/com/example/demo/boundedContext/order/controller/TossController.java
@@ -35,7 +35,7 @@ public class TossController {
             orderService.verifyRequest(orderRequest,rq.getMemberId());
             tossPaymentService.requestPermitToss(orderRequest);
 
-            return rq.redirectWithMsg("redirect:/order/result","결제가 완료되었습니다.");
+            return rq.redirectWithMsg("/order/result","결제가 완료되었습니다.");
 
         } catch (OrderException e1) {
             return rq.historyBack("결제에 실패하였습니다.");

--- a/src/main/java/com/example/demo/boundedContext/order/controller/TossController.java
+++ b/src/main/java/com/example/demo/boundedContext/order/controller/TossController.java
@@ -5,6 +5,7 @@ import com.example.demo.boundedContext.order.dto.OrderRequest;
 import com.example.demo.boundedContext.order.infra.TossPaymentInfra;
 import com.example.demo.boundedContext.order.service.OrderService;
 import com.example.demo.util.rq.Rq;
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
@@ -34,11 +35,13 @@ public class TossController {
             orderService.verifyRequest(orderRequest,rq.getMemberId());
             tossPaymentService.requestPermitToss(orderRequest);
 
-            return "redirect:/order/result";
+            return rq.redirectWithMsg("redirect:/order/result","결제가 완료되었습니다.");
 
-        } catch (OrderException e) {
+        } catch (OrderException e1) {
+            return rq.historyBack("결제에 실패하였습니다.");
 
-            return "order/orderPage";
+        } catch (OptimisticLockException e2) {
+            return rq.historyBack("죄송합니다 잠시후에 다시 이용해주세요.");
         }
     }
 

--- a/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepository.java
@@ -1,10 +1,12 @@
 package com.example.demo.boundedContext.order.repository;
 
 import com.example.demo.boundedContext.order.dto.OrderExchangeDto;
+import com.example.demo.boundedContext.order.entity.OrderDetail;
 
 import java.util.Optional;
 
 public interface CustomOrderDetailRepository {
 
     Optional<OrderExchangeDto> findByOrderIdAndMemberId(Long orderId, Long orderItemId, Long memberId);
+    Optional<OrderDetail> findByIdAndMemberId(Long orderItemId, Long memberId);
 }

--- a/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepositoryImpl.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.example.demo.boundedContext.order.repository;
 
 import com.example.demo.boundedContext.order.dto.OrderExchangeDto;
-import com.example.demo.boundedContext.order.entity.OrderItemStatus;
+import com.example.demo.boundedContext.order.entity.OrderDetail;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -11,7 +11,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-import static com.example.demo.boundedContext.order.entity.OrderItemStatus.*;
+import static com.example.demo.boundedContext.member.entity.QMember.member;
+import static com.example.demo.boundedContext.order.entity.OrderItemStatus.PENDING;
+import static com.example.demo.boundedContext.order.entity.OrderItemStatus.PLACED;
 import static com.example.demo.boundedContext.order.entity.QOrder.order;
 import static com.example.demo.boundedContext.order.entity.QOrderDetail.orderDetail;
 import static com.example.demo.boundedContext.product.entity.QProduct.product;
@@ -32,13 +34,25 @@ public class CustomOrderDetailRepositoryImpl implements CustomOrderDetailReposit
                 .from(order)
                 .join(order.orderDetailList, orderDetail)
                 .join(orderDetail.product, product)
-                .where(equalOrderId(orderId),
-                        equalMember(memberId),
-                        equalOrderItemId(orderItemId),
-                        isBeforeDeliver())
+                .where(equalOrderId(orderId)
+                        .and(equalMember(memberId))
+                        .and(equalOrderItemId(orderItemId))
+                        .and(isBeforeDeliver()))
                 .fetchOne();
 
         return Optional.ofNullable(orderExchangeDto);
+    }
+
+    @Override
+    public Optional<OrderDetail> findByIdAndMemberId(Long orderItemId, Long memberId) {
+
+        OrderDetail orderDetail1 = jpaQueryFactory.selectFrom(orderDetail)
+                .join(orderDetail.order, order)
+                .join(order.member, member)
+                .where(equalOrderId(orderItemId).and(equalMember(memberId)))
+                .fetchOne();
+
+        return Optional.ofNullable(orderDetail1);
     }
 
     private static BooleanExpression isBeforeDeliver() {

--- a/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepositoryImpl.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderDetailRepositoryImpl.java
@@ -34,6 +34,7 @@ public class CustomOrderDetailRepositoryImpl implements CustomOrderDetailReposit
                 .from(order)
                 .join(order.orderDetailList, orderDetail)
                 .join(orderDetail.product, product)
+                .join(order.member,member)
                 .where(equalOrderId(orderId)
                         .and(equalMember(memberId))
                         .and(equalOrderItemId(orderItemId))
@@ -49,7 +50,7 @@ public class CustomOrderDetailRepositoryImpl implements CustomOrderDetailReposit
         OrderDetail orderDetail1 = jpaQueryFactory.selectFrom(orderDetail)
                 .join(orderDetail.order, order)
                 .join(order.member, member)
-                .where(equalOrderId(orderItemId).and(equalMember(memberId)))
+                .where(equalOrderItemId(orderItemId).and(equalMember(memberId)))
                 .fetchOne();
 
         return Optional.ofNullable(orderDetail1);
@@ -68,6 +69,6 @@ public class CustomOrderDetailRepositoryImpl implements CustomOrderDetailReposit
     }
 
     private BooleanExpression equalMember(Long memberId) {
-        return memberId != null ? order.member.id.eq(memberId) : null;
+        return memberId != null ? member.id.eq(memberId) : null;
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderRepositoryImpl.java
+++ b/src/main/java/com/example/demo/boundedContext/order/repository/CustomOrderRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.example.demo.boundedContext.order.repository;
 
 import com.example.demo.boundedContext.order.entity.Order;
 import com.example.demo.boundedContext.order.entity.OrderStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -15,10 +16,17 @@ public class CustomOrderRepositoryImpl implements CustomOrderRepository {
     private final JPAQueryFactory jpaQueryFactory;
     public Optional<Order> findCompleteOrderOneByStatus(Long id, OrderStatus status) {
         Order order1 = jpaQueryFactory.selectFrom(order)
-                .where(order.member.id.eq(id))
-                .where(order.status.eq(status))
+                .where(isEqualMember(id), isEqualStatus(status))
                 .orderBy(order.id.desc()).limit(1L).fetchOne();
 
         return Optional.ofNullable(order1);
+    }
+
+    private static BooleanExpression isEqualStatus(OrderStatus status) {
+        return status != null ? order.status.eq(status) : null;
+    }
+
+    private static BooleanExpression isEqualMember(Long memberId) {
+        return memberId != null ?order.member.id.eq(memberId) : null;
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/service/OrderService.java
+++ b/src/main/java/com/example/demo/boundedContext/order/service/OrderService.java
@@ -7,7 +7,9 @@ import com.example.demo.boundedContext.order.dto.OrderRequest;
 import com.example.demo.boundedContext.order.entity.Order;
 import com.example.demo.boundedContext.order.entity.OrderDetail;
 import com.example.demo.boundedContext.order.entity.OrderStatus;
+import com.example.demo.boundedContext.order.repository.OrderDetailRepository;
 import com.example.demo.boundedContext.order.repository.OrderRepository;
+import com.example.demo.boundedContext.product.entity.Product;
 import com.example.demo.boundedContext.product.event.ProductDecreaseEvent;
 import com.example.demo.util.rq.ResponseData;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ import java.util.Optional;
 public class OrderService {
 
     private final OrderRepository orderRepository;
+    private final OrderDetailRepository orderDetailRepository;
     private final ApplicationEventPublisher publisher;
 
 
@@ -87,5 +90,21 @@ public class OrderService {
 
     public List<Order> findAllByMember(Member member) {
         return orderRepository.findByMember(member);
+    }
+
+
+    public void orderProduct(Member member, Product product, String productName, int count) {
+
+        Order order = Order.builder()
+                .orderName(productName)
+                .member(member)
+                .build();
+        orderRepository.save(order);
+
+        OrderDetail orderDetail = OrderDetail.builder()
+                .count(count)
+                .build();
+        orderDetail.addOrder(order,product);
+        orderDetailRepository.save(orderDetail);
     }
 }

--- a/src/main/java/com/example/demo/boundedContext/order/service/ProductOrderFacade.java
+++ b/src/main/java/com/example/demo/boundedContext/order/service/ProductOrderFacade.java
@@ -1,0 +1,27 @@
+package com.example.demo.boundedContext.order.service;
+
+import com.example.demo.boundedContext.member.entity.Member;
+import com.example.demo.boundedContext.member.repository.MemberRepository;
+import com.example.demo.boundedContext.product.dto.ProductOrderDto;
+import com.example.demo.boundedContext.product.entity.Product;
+import com.example.demo.boundedContext.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class ProductOrderFacade {
+
+    private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
+    private final OrderService orderService;
+    public void createOrderOne(ProductOrderDto dto, Long memberId) {
+
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        Product product = productRepository.findById(dto.getId()).orElseThrow();
+
+        orderService.orderProduct(member, product, product.getName(), dto.getCount());
+    }
+}

--- a/src/main/java/com/example/demo/boundedContext/product/controller/ProductController.java
+++ b/src/main/java/com/example/demo/boundedContext/product/controller/ProductController.java
@@ -1,15 +1,55 @@
 package com.example.demo.boundedContext.product.controller;
 
-import com.example.demo.boundedContext.order.service.OrderDetailService;
+import com.example.demo.boundedContext.order.service.ProductOrderFacade;
+import com.example.demo.boundedContext.product.dto.ProductOrderDto;
+import com.example.demo.boundedContext.product.entity.Product;
+import com.example.demo.boundedContext.product.service.ProductService;
 import com.example.demo.util.rq.Rq;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequiredArgsConstructor
 @RequestMapping("/product")
 @Controller
 public class ProductController {
+
+    private final Rq rq;
+    private final ProductService productService;
+    private final ProductOrderFacade productOrderService;
+
+    @GetMapping("/detail/{id}")
+    public String viewDetailProduct(Model model, @PathVariable(name = "id") Long productId) {
+
+        Product product = productService.findById(productId);
+
+        model.addAttribute("product", product);
+
+        return "product/detail";
+    }
+
+    @PostMapping("/order")
+    public String orderProduct(@Valid ProductOrderDto dto, BindingResult bindingResult) {
+
+        if (bindingResult.hasErrors())
+            return rq.historyBack("잘못된 요청입니다.");
+
+
+        Product product = productService.findById(dto.getId());
+
+        if (product.getCount() < dto.getCount())
+            return rq.historyBack("잘못된 요청입니다.");
+
+        productOrderService.createOrderOne(dto, rq.getMemberId());
+
+        return rq.redirectWithMsg("/order/orderPage","주문하러 가기");
+    }
 
 
 }

--- a/src/main/java/com/example/demo/boundedContext/product/dto/ProductOrderDto.java
+++ b/src/main/java/com/example/demo/boundedContext/product/dto/ProductOrderDto.java
@@ -1,0 +1,18 @@
+package com.example.demo.boundedContext.product.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Setter
+@Getter
+public class ProductOrderDto {
+
+    @NotNull
+    private Long id;
+
+    @Min(1)
+    private int count;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
       spec: maximumSize=1000, expireAfterAccess=5m
   profiles:
     include: secret
-#    active: dev
+    active: dev
 
   jpa:
     generate-ddl: true

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html data-theme="light">
+<html data-theme="light" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
 <head>
     <meta charset="UTF-8">
@@ -27,7 +28,7 @@
             </label>
             <ul tabindex="0" class="menu menu-compact dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-52">
                 <li><a href="/test">MBTI Test</a></li>
-                <li><a href="/member/mypage">My Page</a></li>
+                <li sec:authorize="isAuthenticated()"><a href="/member/mypage">My Page</a></li>
                 <li><a href="#">About</a></li>
             </ul>
         </div>
@@ -42,13 +43,13 @@
         <a href="/map" class="btn btn-ghost btn-circle">
             <i class="fa-regular fa-map"></i>
         </a>
-        <a href="#" class="btn btn-ghost btn-circle">
+        <a sec:authorize="isAuthenticated()" href="#" class="btn btn-ghost btn-circle">
             <i class="fa-regular fa-heart"></i>
         </a>
-        <a href="/member/shoppingbasket" class="btn btn-ghost btn-circle">
+        <a sec:authorize="isAuthenticated()" href="/member/shoppingbasket" class="btn btn-ghost btn-circle">
             <i class="fa-solid fa-cart-shopping"></i>
         </a>
-        <a href="/member/login" class="btn btn-active btn-sm">
+        <a sec:authorize="isAnonymous()" href="/member/login" class="btn btn-active btn-sm">
             Sign in
         </a>
     </div>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -6,9 +6,22 @@
 </head>
 <body>
 
-<main layout:fragment="main">
-    <h1>404</h1>
+
+<main layout:fragment="main" class="grid min-h-full place-items-center bg-white px-6 py-24 sm:py-32 lg:px-8">
+    <div class="text-center">
+        <p class="text-base font-semibold text-indigo-600">404</p>
+        <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">Page not found</h1>
+        <p class="mt-6 text-base leading-7 text-gray-600">Sorry, we couldn’t find the page you’re looking for.</p>
+        <div class="mt-10 flex items-center justify-center gap-x-6">
+            <a href="/"
+               class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Go
+                back home</a>
+            <a href="#" class="text-sm font-semibold text-gray-900">Contact support <span
+                    aria-hidden="true">&rarr;</span></a>
+        </div>
+    </div>
 </main>
+
 
 
 </body>

--- a/src/main/resources/templates/error/4xx.html
+++ b/src/main/resources/templates/error/4xx.html
@@ -6,8 +6,19 @@
 </head>
 <body>
 
-<main layout:fragment="main">
-    <h1>400</h1>
+<main layout:fragment="main" class="grid min-h-full place-items-center bg-white px-6 py-24 sm:py-32 lg:px-8">
+    <div class="text-center">
+        <p class="text-base font-semibold text-indigo-600">BAD</p>
+        <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">Retry</h1>
+        <p class="mt-6 text-base leading-7 text-gray-600">죄송합니다 잠시후에 다시 이용해주세요</p>
+        <div class="mt-10 flex items-center justify-center gap-x-6">
+            <a href="/"
+               class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Go
+                back home</a>
+            <a href="#" class="text-sm font-semibold text-gray-900">Contact support <span
+                    aria-hidden="true">&rarr;</span></a>
+        </div>
+    </div>
 </main>
 
 

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -5,8 +5,19 @@
     <title>Title</title>
 </head>
 <body>
-<main layout:fragment="main">
-    <h1>500</h1>
+<main layout:fragment="main" class="grid min-h-full place-items-center bg-white px-6 py-24 sm:py-32 lg:px-8">
+    <div class="text-center">
+        <p class="text-base font-semibold text-indigo-600">500</p>
+        <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">Server error</h1>
+        <p class="mt-6 text-base leading-7 text-gray-600">죄송합니다 잠시후에 다시 이용해주세요</p>
+        <div class="mt-10 flex items-center justify-center gap-x-6">
+            <a href="/"
+               class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Go
+                back home</a>
+            <a href="#" class="text-sm font-semibold text-gray-900">Contact support <span
+                    aria-hidden="true">&rarr;</span></a>
+        </div>
+    </div>
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/product/detail.html
+++ b/src/main/resources/templates/product/detail.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html layout:decorate="~{common/layout.html}" xmlns="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>교환 반품</title>
+</head>
+<body>
+<main class="min-w-full" layout:fragment="main">
+
+    <div class="flex flex-col border rounded-[20px] justify-content align-items mx-auto w-2/3 ">
+
+        <div class="h-screen flex flex-col justify-center align-items gap-3 mt-3">
+            <h1 class="text-center text-blue-800 text-3xl underline font-bold">제품 상세</h1>
+            <table class="text-center border">
+                <tr>
+                    <th colspan="2" class="text-xl bg-gray-400 font-bold">제품</th>
+                </tr>
+                <tr>
+                    <td class="text-xl border  py-2 font-bold">제품 이름</td>
+                    <td class="text-bold text-xl border py-2  rounded-[20px] px-[10px] " id="orderId"
+                        th:text="|${product.name}|"></td>
+                </tr>
+                <tr>
+                    <td class="text-xl border  py-2 font-bold">가격</td>
+                    <td class="text-bold text-xl border py-2  rounded-[20px] px-[10px] " id="orderDate"
+                        th:text="${product.price}"></td>
+                </tr>
+                <tr>
+                    <td class="text-xl border  py-2 font-bold">남은 수량</td>
+                    <td class="text-bold text-xl border py-2  rounded-[20px] px-[10px] " id="totalAmount"
+                        th:text="${product.count}"></td>
+                </tr>
+
+            </table>
+            <form id="customForm" method="POST" th:action="@{/product/order}" class="w-full max-w-lg flex flex-col justify-content align-items gap-3 mx-auto">
+                <div class="inline-block my-4">
+                    <div class="flex">
+                        <input type="hidden" name="id" th:value="${product.id}">
+                        <button type="button" class="bg-gray-300 text-gray-700 font-bold py-2 px-4 rounded-l" onclick="decrementCount()">-</button>
+                        <input name="count" id="countInput" class="block appearance-none w-full bg-white border border-gray-400 hover:border-gray-500 px-4 py-2 rounded-none shadow leading-tight focus:outline-none focus:shadow-outline text-center" type="text" value="1" readonly>
+                        <button type="button" class="bg-gray-300 text-gray-700 font-bold py-2 px-4 rounded-r" onclick="incrementCount()">+</button>
+                    </div>
+                </div>
+
+                <button class="btn btn-outline btn-primary mt-4" type="button">장바구니에 담기</button>
+                <button class="btn btn-outline btn-accent" onclick="requestOrder(this)">주문하기</button>
+            </form>
+
+
+        </div>
+        <script th:inline="javascript">
+            let count = 1;
+            const countInput = document.getElementById("countInput");
+            const maxCount =/*[[${product.count}]]*/ 10;
+            function incrementCount() {
+                if (count < maxCount) {
+                    count++;
+                    countInput.value = count;
+                }
+            }
+            function decrementCount() {
+                if (count > 1) {
+                    count--;
+                    countInput.value = count;
+                }
+            }
+
+            function requestOrder() {
+                const productId =/*[[${product.id}]]*/ null;
+                const count = document.querySelector("#countInput").value;
+                console.log(productId);
+                console.log("count="+count);
+
+                if (count > maxCount || count < 0) {
+                    alert('잘못된 수량요청입니다. \n 다시 입력해 주세요');
+                    return;
+                }
+                const form = document.querySelector("#customForm");
+                form.submit();
+            }
+        </script>
+</main>
+</body>
+</html>

--- a/src/test/java/com/example/demo/boundedContext/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/example/demo/boundedContext/order/controller/OrderControllerTest.java
@@ -123,7 +123,7 @@ class OrderControllerTest {
                 .andExpect(handler().handlerType(OrderController.class))
                 .andExpect(handler().methodName("exchangePost"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/order/orderInfo"))
+                .andExpect(redirectedUrlPattern("/order/orderInfo**"))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/example/demo/boundedContext/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/example/demo/boundedContext/order/controller/OrderControllerTest.java
@@ -115,7 +115,7 @@ class OrderControllerTest {
 
         OrderExchangeDto dto = new OrderExchangeDto(orderItemId, productName, count, price);
 
-        Mockito.doNothing().when(orderDetailService).returnProduct(orderId,dto);
+        Mockito.doNothing().when(orderDetailService).returnProduct(orderId,dto,1L);
 
         mvc.perform(post("/order/exchange/%d".formatted(orderId))
                         .with(csrf())

--- a/src/test/java/com/example/demo/boundedContext/order/service/OrderDetailServiceTest.java
+++ b/src/test/java/com/example/demo/boundedContext/order/service/OrderDetailServiceTest.java
@@ -67,7 +67,7 @@ class OrderDetailServiceTest {
         OrderExchangeDto dto = new OrderExchangeDto(orderDetail1.getId(), null, 2, product.getPrice());
 
         //when
-        orderDetailService.exchange(dto);
+        orderDetailService.exchange(dto,member.getId());
 
         //then
         assertThat(orderDetail1.getStatus()).isEqualTo(OrderItemStatus.EXCHANGE);
@@ -100,7 +100,7 @@ class OrderDetailServiceTest {
         OrderExchangeDto dto = new OrderExchangeDto(orderDetail1.getId(), product.getName(), 2, product.getPrice());
 
         //when
-        orderDetailService.returnProduct(order.getId(),dto);
+        orderDetailService.returnProduct(order.getId(),dto,member.getId());
 
         //then
         assertThat(orderDetail1.getStatus()).isEqualTo(OrderItemStatus.RETURN);

--- a/src/test/java/com/example/demo/boundedContext/order/service/ProductOrderFacadeTest.java
+++ b/src/test/java/com/example/demo/boundedContext/order/service/ProductOrderFacadeTest.java
@@ -1,0 +1,60 @@
+package com.example.demo.boundedContext.order.service;
+
+import com.example.demo.boundedContext.member.entity.Member;
+import com.example.demo.boundedContext.member.repository.MemberRepository;
+import com.example.demo.boundedContext.order.entity.Order;
+import com.example.demo.boundedContext.order.repository.OrderRepository;
+import com.example.demo.boundedContext.product.dto.ProductOrderDto;
+import com.example.demo.boundedContext.product.entity.Product;
+import com.example.demo.boundedContext.product.repository.ProductRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest
+class ProductOrderFacadeTest {
+
+    @Autowired
+    ProductOrderFacade facade;
+    @Autowired
+    ProductRepository productRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    OrderRepository orderRepository;
+
+    @DisplayName("단일 주문 성공")
+    @Test
+    void t1() {
+        Product product = productRepository.save(Product.builder()
+                .count(10)
+                .price(15000)
+                .name("product1").build());
+
+        Member user = Member.builder()
+                .build();
+        memberRepository.save(user);
+
+        ProductOrderDto dto = new ProductOrderDto();
+        dto.setId(product.getId());
+        int count = 5;
+        dto.setCount(count);
+
+        facade.createOrderOne(dto,user.getId());
+        Order order = orderRepository.findByMember(user).get(0);
+
+        Assertions.assertThat(order.getItemCount()).isEqualTo(count);
+        Assertions.assertThat(order.getTotalPrice()).isEqualTo((long) product.getPrice() * count);
+
+        Product saveProduct = order.getOrderDetailList().get(0).getProduct();
+        Assertions.assertThat(saveProduct.getId()).isEqualTo(product.getId());
+
+    }
+
+}

--- a/src/test/java/com/example/demo/boundedContext/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/example/demo/boundedContext/product/controller/ProductControllerTest.java
@@ -48,6 +48,9 @@ class ProductControllerTest {
     @DisplayName("product get요청")
     @Test
     void t1() throws Exception {
+
+        Mockito.when(productService.findById(1L)).thenReturn(Product.builder().name("product").count(100).build());
+
         mvc.perform(get("/product/detail/%d".formatted(1L)))
                 .andExpect(handler().handlerType(ProductController.class))
                 .andExpect(handler().methodName("viewDetailProduct"))

--- a/src/test/java/com/example/demo/boundedContext/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/example/demo/boundedContext/product/controller/ProductControllerTest.java
@@ -1,0 +1,117 @@
+package com.example.demo.boundedContext.product.controller;
+
+import com.example.demo.boundedContext.order.service.ProductOrderFacade;
+import com.example.demo.boundedContext.product.dto.ProductOrderDto;
+import com.example.demo.boundedContext.product.entity.Product;
+import com.example.demo.boundedContext.product.service.ProductService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest
+class ProductControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    ProductService productService;
+
+    @MockBean
+    ProductOrderFacade facade;
+
+    @WithUserDetails(value = "user1",setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("product get요청")
+    @Test
+    void t1() throws Exception {
+        mvc.perform(get("/product/detail/%d".formatted(1L)))
+                .andExpect(handler().handlerType(ProductController.class))
+                .andExpect(handler().methodName("viewDetailProduct"))
+                .andExpect(content().string(containsString("""
+                        <input name="count" id="countInput"
+                        """.stripIndent().trim())))
+                .andExpect(content().string(containsString("""
+                         <button class="btn btn-outline btn-primary mt-4" type="button">장바구니에 담기</button>
+                        """.stripIndent().trim())))
+                .andExpect(content().string(containsString("""
+                         <button class="btn btn-outline btn-accent" onclick="requestOrder(this)">주문하기</button>
+                        """.stripIndent().trim())))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(view().name("product/detail"))
+                .andDo(print());
+    }
+
+    @WithUserDetails(value = "user1",setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("product 단일 구매 요청 성공")
+    @Test
+    void t2() throws Exception {
+
+        Long productId  = 20L;
+        Long memberId = 1L;
+        int count = 30;
+
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add("id",String.valueOf(productId));
+        map.add("count",String.valueOf(count));
+
+        ProductOrderDto dto = new ProductOrderDto();
+        dto.setId(productId);
+        dto.setCount(count);
+
+        Mockito.when(productService.findById(productId)).thenReturn(Product.builder().count(100).build());
+        Mockito.doNothing().when(facade).createOrderOne(dto,memberId);
+
+        mvc.perform(post("/product/order")
+                        .with(csrf()).params(map))
+                .andExpect(handler().handlerType(ProductController.class))
+                .andExpect(handler().methodName("orderProduct"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("/order/orderPage**"))
+                .andDo(print());
+    }
+
+    @WithUserDetails(value = "user1",setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("product 단일 구매 요청 실패")
+    @Test
+    void t3() throws Exception {
+
+        Long productId  = 20L;
+        int count = 0;
+
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add("id",String.valueOf(productId));
+        map.add("count",String.valueOf(count));
+
+        mvc.perform(post("/product/order")
+                        .with(csrf()).params(map))
+                .andExpect(handler().handlerType(ProductController.class))
+                .andExpect(handler().methodName("orderProduct"))
+                .andExpect(status().is4xxClientError())
+                .andDo(print());
+    }
+
+}


### PR DESCRIPTION
## product 상세 페이지 구현

### 1. product 상세 페이지 구현

- 들어가면 product 이름하고 count만 보이는 상태입니다.
- 바로 결제로 갈 수 있게 구현해 놨습니다.

### 2. error page 구현

- error page를 일부 수정하였습니다.

### 3. exchange 로직 변경

- queryDsl 관련하여 잘못 구현 된 부분을 수정하였습니다.
- 기존: and가 아닌 개별로 동적 쿼리 개념으로 구현해 놓음 -> and로 묶어서 통합으로 검증 테스트로 구현

### 4. ControllerAdvice 구현

-  에러가 나면 ControllerAdvice 로 이동 이후 Rq를 통해 historyBack으로 뒤로가기
-  중요한 에러의 경우는 log를 남기도록 설정