### PR TITLE
Search& Category

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/demo/base/initdata/CustomInitData.java
+++ b/src/main/java/com/example/demo/base/initdata/CustomInitData.java
@@ -178,7 +178,7 @@ public class CustomInitData {
                 admin.addRole(Role.USER);
                 admin.addRole(Role.ADMIN);
                 memberRepository.save(admin);
-                
+
                 Comment comment = Comment.builder()
                         .faq(faq1).content("test content").build();
                 commentRepository.save(comment);

--- a/src/main/java/com/example/demo/base/initdata/CustomInitData.java
+++ b/src/main/java/com/example/demo/base/initdata/CustomInitData.java
@@ -46,12 +46,53 @@ public class CustomInitData {
             @Override
             @Transactional
             public void run(String... args) throws Exception {
+                List<Category> categories = new ArrayList<>();
+                categories.add(Category.builder().name("istj").build());
+                categories.add(Category.builder().name("isfj").build());
+                categories.add(Category.builder().name("infj").build());
+                categories.add(Category.builder().name("intj").build());
+                categories.add(Category.builder().name("istp").build());
+                categories.add(Category.builder().name("isfp").build());
+                categories.add(Category.builder().name("infp").build());
+                categories.add(Category.builder().name("intp").build());
+                categories.add(Category.builder().name("estp").build());
+                categories.add(Category.builder().name("esfp").build());
+                categories.add(Category.builder().name("enfp").build());
+                categories.add(Category.builder().name("entp").build());
+                categories.add(Category.builder().name("estj").build());
+                categories.add(Category.builder().name("esfj").build());
+                categories.add(Category.builder().name("enfj").build());
+                categories.add(Category.builder().name("entj").build());
+
+                categoryRepository.saveAll(categories);
+
+                Product save = productRepository.save(
+                        Product.builder()
+                                .category(categories.get(0))
+                                .name("뱅갈고무나무")
+                                .price(39000)
+                                .count(3)
+                                .salePrice(25000)
+                                .build()
+                );
+
+                Product save2 = productRepository.save(
+                        Product.builder()
+                                .category(categories.get(1))
+                                .name("산세베리아")
+                                .price(39000)
+                                .count(1)
+                                .salePrice(21000)
+                                .build()
+                );
                 Product product1 = productRepository.save(Product.builder()
                                 .count(10)
                         .price(15000)
+                        .category(categories.get(2))
                         .name("product1").build());
                 Product product2 = productRepository.save(Product.builder()
                         .count(100)
+                        .category(categories.get(3))
                         .price(10000)
                         .name("product2").build());
 
@@ -137,54 +178,13 @@ public class CustomInitData {
                 admin.addRole(Role.USER);
                 admin.addRole(Role.ADMIN);
                 memberRepository.save(admin);
-
-                List<Category> categories = new ArrayList<>();
-
-                categories.add(Category.builder().id(1L).name("istj").build());
-                categories.add(Category.builder().id(2L).name("isfj").build());
-                categories.add(Category.builder().id(3L).name("infj").build());
-                categories.add(Category.builder().id(4L).name("intj").build());
-                categories.add(Category.builder().id(5L).name("istp").build());
-                categories.add(Category.builder().id(6L).name("isfp").build());
-                categories.add(Category.builder().id(7L).name("infp").build());
-                categories.add(Category.builder().id(8L).name("intp").build());
-                categories.add(Category.builder().id(9L).name("estp").build());
-                categories.add(Category.builder().id(10L).name("esfp").build());
-                categories.add(Category.builder().id(11L).name("enfp").build());
-                categories.add(Category.builder().id(12L).name("entp").build());
-                categories.add(Category.builder().id(13L).name("estj").build());
-                categories.add(Category.builder().id(14L).name("esfj").build());
-                categories.add(Category.builder().id(15L).name("enfj").build());
-                categories.add(Category.builder().id(16L).name("entj").build());
-
-                categoryRepository.saveAll(categories);
-
-
-                Product save = productRepository.save(
-                        Product.builder()
-                                .category(categories.get(0))
-                                .name("뱅갈고무나무")
-                                .price(39000)
-                                .count(3)
-                                .salePrice(25000)
-                                .build()
-                );
-
-                Product save2 = productRepository.save(
-                        Product.builder()
-                                .category(categories.get(1))
-                                .name("산세베리아")
-                                .price(39000)
-                                .count(1)
-                                .salePrice(21000)
-                                .build()
-                );
-
+                
                 Comment comment = Comment.builder()
                         .faq(faq1).content("test content").build();
                 commentRepository.save(comment);
                 Faq _faq1 = faq1.toBuilder().comment(comment).build();
                 faqRepository.save(_faq1);
+
             }
         };
       }

--- a/src/main/java/com/example/demo/base/shop/SearchController.java
+++ b/src/main/java/com/example/demo/base/shop/SearchController.java
@@ -1,0 +1,37 @@
+package com.example.demo.base.shop;
+
+import com.example.demo.boundedContext.product.entity.Product;
+import com.example.demo.boundedContext.product.repository.ProductRepository;
+import com.example.demo.boundedContext.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+@Controller
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final ProductService productService;
+    private final ProductRepository productRepository;
+
+    @GetMapping("/search")
+    public String showSearch(@PageableDefault(size = 12, page = 0, direction = DESC, sort = "created") Pageable pageable,
+                             @RequestParam(value = "keyword", defaultValue = "") String keyword,
+                             Model model) {
+
+        Page<Product> paging = productService.findAllByCategoryNameAndKeyword(null, keyword, pageable);
+
+        model.addAttribute("paging", paging);
+        model.addAttribute("keyword", keyword);
+        return "shop/search";
+    }
+}

--- a/src/main/java/com/example/demo/base/shop/ShopService.java
+++ b/src/main/java/com/example/demo/base/shop/ShopService.java
@@ -20,7 +20,7 @@ public class ShopService {
     private final CategoryRepository categoryRepository;
 
     public Page<Product> getList(String categoryName, Pageable pageable) {
-        return productService.findAllByCategoryName(categoryName, pageable);
+        return productService.findAllByCategoryNameAndKeyword(categoryName, null, pageable);
     }
 
     public Optional<Category> categoryView(Long id){

--- a/src/main/java/com/example/demo/boundedContext/category/entity/Category.java
+++ b/src/main/java/com/example/demo/boundedContext/category/entity/Category.java
@@ -6,15 +6,10 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @Getter
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder(toBuilder = true)
 @Entity
 public class Category extends BaseEntity {
-
-    @Column(nullable = false)
-    @Id
-    private Long id;
     private String name;
-
 }

--- a/src/main/java/com/example/demo/boundedContext/product/entity/Product.java
+++ b/src/main/java/com/example/demo/boundedContext/product/entity/Product.java
@@ -28,10 +28,13 @@ public class Product extends BaseEntity {
     private int price;
     private int salePrice;
     private int count;
+    private  String imageUrl;
+
 
     @Builder.Default
     @OneToMany(mappedBy = "product",cascade = CascadeType.ALL,orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();
+    
 
 
     @Version

--- a/src/main/java/com/example/demo/boundedContext/product/repository/ProductQueryDslRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/product/repository/ProductQueryDslRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ProductQueryDslRepository {
-    Page<Product> findAllByCategoryName(String categoryName, String keyword, Pageable pageable);
+    Page<Product> findAllByCategoryNameAndKeyword(String categoryName, String keyword, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/boundedContext/product/service/ProductService.java
+++ b/src/main/java/com/example/demo/boundedContext/product/service/ProductService.java
@@ -25,9 +25,8 @@ public class ProductService {
                 .orElseThrow(() -> new DataNotFoundException("존재하지 않는 데이터입니다"));
     }
 
-    public Page<Product> findAllByCategoryName(String categoryName, Pageable pageable) {
-        return productRepository.findAllByCategoryName(categoryName, null, pageable);
+    public Page<Product> findAllByCategoryNameAndKeyword(String categoryName, String keyword, Pageable pageable) {
+        return productRepository.findAllByCategoryNameAndKeyword(categoryName, keyword, pageable);
     }
-
 
 }

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -40,7 +40,7 @@
         <a href="/shop" class="btn btn-ghost normal-case">PLANBTI</a>
     </div>
     <div class="navbar-end pr-4">
-        <a href="#" class="btn btn-ghost btn-circle">
+        <a href="/search" class="btn btn-ghost btn-circle">
             <i class="fa-solid fa-magnifying-glass"></i>
         </a>
         <a href="/map" class="btn btn-ghost btn-circle">

--- a/src/main/resources/templates/shop/search.html
+++ b/src/main/resources/templates/shop/search.html
@@ -1,0 +1,45 @@
+<html layout:decorate="~{common/layout.html}">
+<head>
+    <title>SEARCH</title>
+</head>
+
+<body>
+
+<main layout:fragment="main" class="container mx-12 py-8 min-h-screen">
+    <div style="text-align:center">
+        <h1 class="text-xl mb-10"><b>상품 검색</b></h1>
+
+        <form th:action th:method="get">
+            <input name="keyword" th:value="${keyword}" type="text" placeholder="검색할 상품명을 입력하세요" class="input input-bordered input-accent w-full max-w-xs" />
+            <button class="btn btn-success">검색</button>
+        </form>
+    </div>
+    </div>
+
+
+<div  div th:if="${!paging.isEmpty()}" class="card card-compact w-96 bg-base-100 shadow-xl">
+    <a th:href="@{/product/detail/{id}(id=${product.getId()})}" class="w-60 h-64 bg-base-100 m-4" th:each="product : ${paging}">
+    <figure><img src="/image/plant1.jpeg" alt="Product" /></figure>
+    <div class="card-body">
+        <h2 class="card-title" th:text="${product.getName()}"></h2>
+        <p th:text="|${product.getSalePrice()} 원|"></p>
+        <div class="card-actions justify-end">
+            <button class="btn btn-primary">상세보기</button>
+        </div>
+    </div>
+</div>
+
+</main>
+
+<footer class="bg-green-100 py-8">
+    <div class="container mx-auto text-center">
+        <p><i class="fa-regular fa-copyright"></i> 2023 <b>PLANBTI</b>. All rights reserved.</p>
+    </div>
+</footer>
+</body>
+
+
+
+</html>
+</body>
+</html>

--- a/src/main/resources/templates/shop/shopMain.html
+++ b/src/main/resources/templates/shop/shopMain.html
@@ -6,8 +6,8 @@
 
 <body>
 
-<main layout:fragment="main" class="container mx-12 py-8 min-h-screen">
-    <div class="flex flex-col mt-24">
+<main layout:fragment="main" class="container mx-12 py-8">
+    <div class="flex flex-row mt-24">
         <ul class="menu bg-base-100 w-60 flex-none">
             <th:block th:each="category : ${categories}">
                 <li><a  th:href="@{/shop/{category}(category=${category})}" th:text="${category.name}"></a></li>
@@ -47,9 +47,6 @@
 </div>
 <!-- 페이징처리 끝 -->
 
-<footer class="bg-green-100 py-8">
-    <div class="container mx-auto text-center">
-        <p><i class="fa-regular fa-copyright"></i> 2023 <b>PLANBTI</b>. All rights reserved.</p>
 </main>
 
 </body>


### PR DESCRIPTION
### Search
***
- 기본 레이아웃의 돋보기를 누르면 검색 페이지(search)로 이동합니다.

- 검색 페이지 생성하였습니다. 
키워드로 검색 가능. ex) '산' 검색 -> '산세베리아'  반환

- 검색 페이지로 넘어가면 상품이 밑에 다 떠있고 검색을 하고 나면 검색된 상품만 보여줍니다.
검색된 상품에 상세보기 버튼을 누르면 상품 상세페이지로 이동합니다.
검색 로직은 잘 작동하나 ui 수정해야 합니다.

- 검색 결과로 뜨는 이미지는 일단 하나로 통일해둔 상태입니다.

### Category
***
- 카테고리를 누르면 카테고리 물건이 뜰 수 있도록 shopMain.html을 변경해야 하는데 아직 방법을 못찾았습니다.! 
아시는 분은 코드 리뷰 부탁드립니다.

- CategoryEntitiy의 ID annotation  BaseEntity와 중복되어 삭제했습니다.
