### PR TITLE
feat & refactor: 테스트 결과 저장 및 MbtiTest 관련 코드수정

### DIFF
--- a/src/main/java/com/example/demo/boundedContext/member/controller/MbtiTestController.java
+++ b/src/main/java/com/example/demo/boundedContext/member/controller/MbtiTestController.java
@@ -18,7 +18,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -47,11 +49,10 @@ public class MbtiTestController {
     @PostMapping("/send")
     public ResponseEntity<String> send(String message, HttpServletResponse response) {
         RestTemplate restTemplate = new RestTemplate();
-
-        if (!checkMessage(message)) {
-            // 요청 값이 유효하지 않을 경우 에러 처리
-            return ResponseEntity.badRequest().body("Invalid request");
-        }
+//        if (!checkMessage(message)) {
+//            // 요청 값이 유효하지 않을 경우 에러 처리
+//            return ResponseEntity.badRequest().body("Invalid request");
+//        }
 
         URI uri = UriComponentsBuilder
                 .fromUriString("https://api.openai.com/v1/chat/completions")
@@ -62,8 +63,10 @@ public class MbtiTestController {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Authorization", "Bearer " + chatGptkey);
 
-        ArrayList<Message> list = new ArrayList<>();
-        list.add(new Message("user", message));
+        ArrayList<MbtiTestController.Message> list = new ArrayList<>();
+//        list.add(new MbtiTestController.Message("user", message));
+        list.add(new MbtiTestController.Message("user", "(이름)" + "(설명)" + "양식으로" + message + "에 어울리는 흔한 식물 하나만 추천해줘 \"(이름)\"은 h1 태그로, \"(설명)\"은 p 태그로 보여줘(\n은 제외시켜줘)"));
+
 
         Body param = new Body("gpt-3.5-turbo", list);
 
@@ -72,18 +75,48 @@ public class MbtiTestController {
         ResponseEntity<String> responseEntity = restTemplate.exchange(httpEntity, String.class);
 
         String responseBody = responseEntity.getBody();
+//        String plantName = "";
+//        String plantDescription = "";
         // JSON에서 식물 이름만 추출
-        String originalString = responseBody;
-        String patternString = "<h1>(.*?)</h1>";
+//        String originalString = responseBody;
+//        String originalString1 = responseBody;
+//        String originalString2 = responseBody;
+//        String patternString1 = "<h1>(.*?)</h1>;
+//        String patternString2 = "<p>(.*?)</p>";
+////        String patternString = "\"content\":\"(.*?)\"";
+//        Pattern pattern = Pattern.compile(patternString);
+//        Matcher matcher = pattern.matcher(originalString);
+//
+//        String patternString2 = "<p>(.*?)</p>";
+//        Pattern pattern2 = Pattern.compile(patternString2);
+//        Matcher matcher2 = pattern2.matcher(originalString2);
+//
+//
+//        if (matcher.find()) {
+////            String mbtiTestResult = matcher.group(1);
+//            String plantName = matcher.group(1);
+//            String plantDescription = matcher.group(2);
+////            String mbtiTestResult = matcher.group(1);
+//            // 쿠키 결과 추가
+//            setCookie(response, "mbti", message);
+//            setCookie(response, "plantName", plantName);
+////            setCookie(response, "plantName", plantName);
+//            setCookie(response, "plantDescription", plantDescription);
+//        }
+//        if(matcher2.find()){
+//            String plantDescription = matcher2.group(1);
+//            setCookie(response, "plantDescription", plantDescription);
+//        }
+//        String responseBody = responseEntity.getBody();
 
-        Pattern pattern = Pattern.compile(patternString);
-        Matcher matcher = pattern.matcher(originalString);
+        setCookie(response, "mbti", message);
 
-        if (matcher.find()) {
-            String mbtiTestResult = matcher.group(1);
-            // 쿠키 결과 추가
-            setCookie(response, "mbtiTestResult", mbtiTestResult);
-        }
+        // Extract plant name from <h1> tag and set cookie
+        extractContentAndSetCookie(responseBody, response, "<h1>(.*?)</h1>", "plantName");
+
+        // Extract plant description from <p> tag and set cookie
+        extractContentAndSetCookie(responseBody, response, "<p>(.*?)</p>", "plantDescription");
+
         return responseEntity;
     }
     // 유효성 검증 체크 메소드
@@ -94,16 +127,36 @@ public class MbtiTestController {
 
         String compare = "";
         if (matcher.find()) {
-            String mbti = matcher.group(1);
-            compare = "(이름)" + "(설명)" + "양식으로" + mbti + "에 어울리는 흔한 식물 하나만 추천해줘 \"(이름)\"은 h1 태그로 보여줘";
+            String mbti = matcher.group(1).replace("\\n", ""); ;
+            compare = "(이름)" + "(설명)" + "양식으로" + mbti + "에 어울리는 흔한 식물 하나만 추천해줘 \"(이름)\"은 h1 태그로, \"(설명)\"은 p 태그로 보여줘";
         }
         return message.equals(compare);
     }
 
+    private void extractContentAndSetCookie(String responseBody, HttpServletResponse response, String patternString, String cookieName) {
+        Pattern pattern = Pattern.compile(patternString);
+        Matcher matcher = pattern.matcher(responseBody);
+
+        if (matcher.find()) {
+            String content = matcher.group(1);
+            // Add content to cookie
+            setCookie(response, cookieName, content);
+        }
+    }
+
     // 쿠키를 생성하고 값을 설정하는 메서드
     public void setCookie(HttpServletResponse response, String name, String value) {
-        Cookie cookie = new Cookie(name, value);
-        response.addCookie(cookie);
+        value = value.replace("\\", "");
+        value = value.replace("n", "<br>");
+        try {
+            String encodedValue = URLEncoder.encode(value, "UTF-8");
+            Cookie cookie = new Cookie(name, encodedValue);
+            response.addCookie(cookie);
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+//        Cookie cookie = new Cookie(name, value);
+//        response.addCookie(cookie);
+        }
     }
 
     @AllArgsConstructor

--- a/src/main/java/com/example/demo/boundedContext/member/controller/MbtiTestController.java
+++ b/src/main/java/com/example/demo/boundedContext/member/controller/MbtiTestController.java
@@ -49,10 +49,10 @@ public class MbtiTestController {
     @PostMapping("/send")
     public ResponseEntity<String> send(String message, HttpServletResponse response) {
         RestTemplate restTemplate = new RestTemplate();
-//        if (!checkMessage(message)) {
-//            // 요청 값이 유효하지 않을 경우 에러 처리
-//            return ResponseEntity.badRequest().body("Invalid request");
-//        }
+        if (!isValidMBTI(message)) {
+            // 요청 값이 유효하지 않을 경우 에러 처리
+            return ResponseEntity.badRequest().body("Invalid request");
+        }
 
         URI uri = UriComponentsBuilder
                 .fromUriString("https://api.openai.com/v1/chat/completions")
@@ -64,7 +64,6 @@ public class MbtiTestController {
         httpHeaders.add("Authorization", "Bearer " + chatGptkey);
 
         ArrayList<MbtiTestController.Message> list = new ArrayList<>();
-//        list.add(new MbtiTestController.Message("user", message));
         list.add(new MbtiTestController.Message("user", "(이름)" + "(설명)" + "양식으로" + message + "에 어울리는 흔한 식물 하나만 추천해줘 \"(이름)\"은 h1 태그로, \"(설명)\"은 p 태그로 보여줘(\n은 제외시켜줘)"));
 
 
@@ -75,62 +74,25 @@ public class MbtiTestController {
         ResponseEntity<String> responseEntity = restTemplate.exchange(httpEntity, String.class);
 
         String responseBody = responseEntity.getBody();
-//        String plantName = "";
-//        String plantDescription = "";
-        // JSON에서 식물 이름만 추출
-//        String originalString = responseBody;
-//        String originalString1 = responseBody;
-//        String originalString2 = responseBody;
-//        String patternString1 = "<h1>(.*?)</h1>;
-//        String patternString2 = "<p>(.*?)</p>";
-////        String patternString = "\"content\":\"(.*?)\"";
-//        Pattern pattern = Pattern.compile(patternString);
-//        Matcher matcher = pattern.matcher(originalString);
-//
-//        String patternString2 = "<p>(.*?)</p>";
-//        Pattern pattern2 = Pattern.compile(patternString2);
-//        Matcher matcher2 = pattern2.matcher(originalString2);
-//
-//
-//        if (matcher.find()) {
-////            String mbtiTestResult = matcher.group(1);
-//            String plantName = matcher.group(1);
-//            String plantDescription = matcher.group(2);
-////            String mbtiTestResult = matcher.group(1);
-//            // 쿠키 결과 추가
-//            setCookie(response, "mbti", message);
-//            setCookie(response, "plantName", plantName);
-////            setCookie(response, "plantName", plantName);
-//            setCookie(response, "plantDescription", plantDescription);
-//        }
-//        if(matcher2.find()){
-//            String plantDescription = matcher2.group(1);
-//            setCookie(response, "plantDescription", plantDescription);
-//        }
-//        String responseBody = responseEntity.getBody();
 
         setCookie(response, "mbti", message);
 
-        // Extract plant name from <h1> tag and set cookie
+        // <h1> 태그에서 plantName 추출 후 쿠키 설정
         extractContentAndSetCookie(responseBody, response, "<h1>(.*?)</h1>", "plantName");
 
-        // Extract plant description from <p> tag and set cookie
+        // <p> 태그에서 plantDescription 추출 후 쿠키 설정
         extractContentAndSetCookie(responseBody, response, "<p>(.*?)</p>", "plantDescription");
 
         return responseEntity;
     }
-    // 유효성 검증 체크 메소드
-    private boolean checkMessage(String message) {
-        String pattern = "([IE][SN][TF][PJ])";
-        Pattern mbtiPattern = Pattern.compile(pattern);
-        Matcher matcher = mbtiPattern.matcher(message);
 
-        String compare = "";
-        if (matcher.find()) {
-            String mbti = matcher.group(1).replace("\\n", ""); ;
-            compare = "(이름)" + "(설명)" + "양식으로" + mbti + "에 어울리는 흔한 식물 하나만 추천해줘 \"(이름)\"은 h1 태그로, \"(설명)\"은 p 태그로 보여줘";
-        }
-        return message.equals(compare);
+    // MBTI 유형 검증 메소드
+    private boolean isValidMBTI(String mbti) {
+        String pattern = "^([IE][SN][TF][PJ])$";
+        Pattern mbtiPattern = Pattern.compile(pattern);
+        Matcher matcher = mbtiPattern.matcher(mbti);
+
+        return matcher.matches();
     }
 
     private void extractContentAndSetCookie(String responseBody, HttpServletResponse response, String patternString, String cookieName) {
@@ -139,7 +101,7 @@ public class MbtiTestController {
 
         if (matcher.find()) {
             String content = matcher.group(1);
-            // Add content to cookie
+            // 쿠키 추가
             setCookie(response, cookieName, content);
         }
     }
@@ -154,8 +116,6 @@ public class MbtiTestController {
             response.addCookie(cookie);
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
-//        Cookie cookie = new Cookie(name, value);
-//        response.addCookie(cookie);
         }
     }
 

--- a/src/main/java/com/example/demo/boundedContext/member/controller/MbtiTestController.java
+++ b/src/main/java/com/example/demo/boundedContext/member/controller/MbtiTestController.java
@@ -108,8 +108,6 @@ public class MbtiTestController {
 
     // 쿠키를 생성하고 값을 설정하는 메서드
     public void setCookie(HttpServletResponse response, String name, String value) {
-        value = value.replace("\\", "");
-        value = value.replace("n", "<br>");
         try {
             String encodedValue = URLEncoder.encode(value, "UTF-8");
             Cookie cookie = new Cookie(name, encodedValue);

--- a/src/main/java/com/example/demo/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/example/demo/boundedContext/member/controller/MemberController.java
@@ -118,13 +118,16 @@ public class MemberController {
         // 로그인된 사용자 정보를 가져옵니다
         Member member = memberService.findByUsernameAndDeleteDateIsNull(rq.getUsername());
 
+        // 디코딩
         try {
             String decodedPlantName = URLDecoder.decode(plantName, "UTF-8");
             String decodedPlantDescription = URLDecoder.decode(plantDescription, "UTF-8");
 
-            if (!testService.isTestExist(member.getUsername(), mbti, decodedPlantName, decodedPlantDescription)){
+            // 동일한 값 create 방지
+            if (!testService.isTestExist(member.getUsername(), mbti, decodedPlantName)){
                 testService.create(member, mbti, decodedPlantName, decodedPlantDescription);
             }
+            // memberUsername 동일한 유저의 테스크 결과 가져오기
             List<MbtiTest> tests = testService.findAllTestsByMember(member);
             model.addAttribute("tests", tests);
 

--- a/src/main/java/com/example/demo/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/example/demo/boundedContext/member/controller/MemberController.java
@@ -93,8 +93,8 @@ public class MemberController {
     @GetMapping("/testresult")
     public String showTestResult(Model model, HttpServletRequest request) {
         String mbti = null;
-        String plantName = null;  // 두 번째 쿠키의 이름을 적어주세요.
-        String plantDescription = null;  // 세 번째 쿠키의 이름을 적어주세요.
+        String plantName = null;
+        String plantDescription = null;
 
         // 쿠키 읽기
         Cookie[] cookies = request.getCookies();
@@ -122,17 +122,12 @@ public class MemberController {
             String decodedPlantName = URLDecoder.decode(plantName, "UTF-8");
             String decodedPlantDescription = URLDecoder.decode(plantDescription, "UTF-8");
 
-                // 이제 decodedValue 변수에는 원래의 쿠키 값이 저장되어 있습니다.
-                // 쿠키로부터 얻은 값을 가지고 새로운 MbtiTest를 생성하고 저장합니다
-//                MbtiTest mbtiTest = MbtiTest.builder()
-//                        .member(member)
-//                        .title(decodedPlantName)
-//                        .content(decodedPlantDescription)
-//                        .build();
-            if (!testService.isTestExist(mbti, decodedPlantName, decodedPlantDescription)){
-                MbtiTest mbtiTest = testService.create(member, mbti, decodedPlantName, decodedPlantDescription);
-                model.addAttribute("testresults", mbtiTest);
+            if (!testService.isTestExist(member.getUsername(), mbti, decodedPlantName, decodedPlantDescription)){
+                testService.create(member, mbti, decodedPlantName, decodedPlantDescription);
             }
+            List<MbtiTest> tests = testService.findAllTestsByMember(member);
+            model.addAttribute("tests", tests);
+
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/example/demo/boundedContext/member/entity/MbtiTest.java
+++ b/src/main/java/com/example/demo/boundedContext/member/entity/MbtiTest.java
@@ -3,10 +3,7 @@ package com.example.demo.boundedContext.member.entity;
 import com.example.demo.base.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @Getter
@@ -16,7 +13,9 @@ import lombok.experimental.SuperBuilder;
 @Entity
 public class MbtiTest extends BaseEntity {
 
-    private char result;
+    private String memberUsername;
+    private String result;
+    private String title;
     private String content;
 
     @ManyToOne

--- a/src/main/java/com/example/demo/boundedContext/member/repository/MbtiTestRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/member/repository/MbtiTestRepository.java
@@ -12,4 +12,6 @@ public interface MbtiTestRepository extends JpaRepository<MbtiTest, Long> {
     Optional<MbtiTest> findByMemberUsernameAndResultAndTitle(String memberUsername, String result, String title);
     List<MbtiTest> findAllByMemberUsername(String memberUsername);
 
+    Optional<MbtiTest> findByMemberUsername(String memberUsername);
+
 }

--- a/src/main/java/com/example/demo/boundedContext/member/repository/MbtiTestRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/member/repository/MbtiTestRepository.java
@@ -1,10 +1,14 @@
 package com.example.demo.boundedContext.member.repository;
 
 import com.example.demo.boundedContext.member.entity.MbtiTest;
+import com.example.demo.boundedContext.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MbtiTestRepository extends JpaRepository<MbtiTest, Long> {
     Optional<MbtiTest> findByIdAndDeleteDateIsNull(Long id);
+
+    Optional<MbtiTest> findByResultAndTitleAndContent(String result, String title, String content);
 }

--- a/src/main/java/com/example/demo/boundedContext/member/repository/MbtiTestRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/member/repository/MbtiTestRepository.java
@@ -9,8 +9,7 @@ import java.util.Optional;
 
 public interface MbtiTestRepository extends JpaRepository<MbtiTest, Long> {
     Optional<MbtiTest> findByIdAndDeleteDateIsNull(Long id);
-    Optional<MbtiTest> findByMemberUsernameAndResultAndTitleAndContent(String memberUsername, String result, String title, String content);
-
+    Optional<MbtiTest> findByMemberUsernameAndResultAndTitle(String memberUsername, String result, String title);
     List<MbtiTest> findAllByMemberUsername(String memberUsername);
 
 }

--- a/src/main/java/com/example/demo/boundedContext/member/repository/MbtiTestRepository.java
+++ b/src/main/java/com/example/demo/boundedContext/member/repository/MbtiTestRepository.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 
 public interface MbtiTestRepository extends JpaRepository<MbtiTest, Long> {
     Optional<MbtiTest> findByIdAndDeleteDateIsNull(Long id);
+    Optional<MbtiTest> findByMemberUsernameAndResultAndTitleAndContent(String memberUsername, String result, String title, String content);
 
-    Optional<MbtiTest> findByResultAndTitleAndContent(String result, String title, String content);
+    List<MbtiTest> findAllByMemberUsername(String memberUsername);
+
 }

--- a/src/main/java/com/example/demo/boundedContext/member/service/TestService.java
+++ b/src/main/java/com/example/demo/boundedContext/member/service/TestService.java
@@ -33,8 +33,8 @@ public class TestService {
         return test.get();
     }
 
-    public boolean isTestExist(String memberUsername, String result, String title, String content) {
-        return mbtiTestRepository.findByMemberUsernameAndResultAndTitleAndContent(memberUsername, result, title, content).isPresent();
+    public boolean isTestExist(String memberUsername, String result, String title) {
+        return mbtiTestRepository.findByMemberUsernameAndResultAndTitle(memberUsername, result, title).isPresent();
     }
 
     public List<MbtiTest> findAllTestsByMember(Member member) {

--- a/src/main/java/com/example/demo/boundedContext/member/service/TestService.java
+++ b/src/main/java/com/example/demo/boundedContext/member/service/TestService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -32,14 +33,18 @@ public class TestService {
         return test.get();
     }
 
-    public boolean isTestExist(String result, String title, String content) {
-        return mbtiTestRepository.findByResultAndTitleAndContent(result, title, content).isPresent();
+    public boolean isTestExist(String memberUsername, String result, String title, String content) {
+        return mbtiTestRepository.findByMemberUsernameAndResultAndTitleAndContent(memberUsername, result, title, content).isPresent();
+    }
+
+    public List<MbtiTest> findAllTestsByMember(Member member) {
+        return mbtiTestRepository.findAllByMemberUsername(member.getUsername());
     }
 
     public MbtiTest create(Member member, String result, String title, String content) {
         MbtiTest test = MbtiTest
                 .builder()
-                .memberUsername(member.getUsername()) // 중요하지 않음
+                .memberUsername(member.getUsername())
                 .result(result)
                 .title(title)
                 .content(content)

--- a/src/main/java/com/example/demo/boundedContext/member/service/TestService.java
+++ b/src/main/java/com/example/demo/boundedContext/member/service/TestService.java
@@ -40,6 +40,10 @@ public class TestService {
         return mbtiTestRepository.findByMemberUsernameAndResultAndTitle(memberUsername, result, title).isPresent();
     }
 
+    public boolean isMemberExist(String memberUsername) {
+        return mbtiTestRepository.findByMemberUsername(memberUsername).isPresent();
+    }
+
     public List<MbtiTest> findAllTestsByMember(Member member) {
         return mbtiTestRepository.findAllByMemberUsername(member.getUsername());
     }
@@ -60,8 +64,9 @@ public class TestService {
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }
-        return new ArrayList<>();  // 예외 발생 시 빈 리스트 반환
+        return new ArrayList<>(); // 예외 발생 시 빈 리스트 반환
     }
+
 
     public MbtiTest create(Member member, String result, String title, String content) {
         MbtiTest test = MbtiTest

--- a/src/main/java/com/example/demo/boundedContext/member/service/TestService.java
+++ b/src/main/java/com/example/demo/boundedContext/member/service/TestService.java
@@ -7,7 +7,10 @@ import com.example.demo.boundedContext.member.repository.MbtiTestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,6 +42,25 @@ public class TestService {
 
     public List<MbtiTest> findAllTestsByMember(Member member) {
         return mbtiTestRepository.findAllByMemberUsername(member.getUsername());
+    }
+
+    public List<MbtiTest> createTestResult(Member member, String mbti, String plantName, String plantDescription) {
+        // plantName과 plantDescription 디코드
+        try {
+            String decodedPlantName = URLDecoder.decode(plantName, "UTF-8");
+            String decodedPlantDescription = URLDecoder.decode(plantDescription, "UTF-8");
+
+            // 중복 항목 생성 방지
+            if (!isTestExist(member.getUsername(), mbti, decodedPlantName)){
+                create(member, mbti, decodedPlantName, decodedPlantDescription);
+            }
+            // 멤버의 테스트를 가져옴
+            return findAllTestsByMember(member);
+
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        return new ArrayList<>();  // 예외 발생 시 빈 리스트 반환
     }
 
     public MbtiTest create(Member member, String result, String title, String content) {

--- a/src/main/java/com/example/demo/boundedContext/member/service/TestService.java
+++ b/src/main/java/com/example/demo/boundedContext/member/service/TestService.java
@@ -2,6 +2,7 @@ package com.example.demo.boundedContext.member.service;
 
 import com.example.demo.base.exception.handler.DataNotFoundException;
 import com.example.demo.boundedContext.member.entity.MbtiTest;
+import com.example.demo.boundedContext.member.entity.Member;
 import com.example.demo.boundedContext.member.repository.MbtiTestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,10 +32,16 @@ public class TestService {
         return test.get();
     }
 
-    public MbtiTest create(char result, String content) {
+    public boolean isTestExist(String result, String title, String content) {
+        return mbtiTestRepository.findByResultAndTitleAndContent(result, title, content).isPresent();
+    }
+
+    public MbtiTest create(Member member, String result, String title, String content) {
         MbtiTest test = MbtiTest
                 .builder()
+                .memberUsername(member.getUsername()) // 중요하지 않음
                 .result(result)
+                .title(title)
                 .content(content)
                 .build();
 

--- a/src/main/resources/templates/member/mbtiTest.html
+++ b/src/main/resources/templates/member/mbtiTest.html
@@ -158,12 +158,12 @@
                 ($("#TF").val() < 2) ? mbti += "F" : mbti += "T";
                 ($("#JP").val() < 2) ? mbti += "P" : mbti += "J";
               
-                message += "(이름)" + "(설명)" + "양식으로" + mbti + "에 어울리는 흔한 식물 하나만 추천해줘 \"(이름)\"은 h1 태그로 보여줘";
+                // message += "(이름)" + "(설명)" + "양식으로" + mbti + "에 어울리는 흔한 식물 하나만 추천해줘 \"(이름)\"은 h1 태그로 보여줘";
 
                 $.ajax({
                     url: "/send",
                     type: "POST",
-                    data: {message: message},
+                    data: {message: mbti},
                     success: function (response) {
                         var chatContainer = $("#chat-container");
                         var assistantMessage = response.choices[0].message.content;

--- a/src/main/resources/templates/member/mbtiTest.html
+++ b/src/main/resources/templates/member/mbtiTest.html
@@ -1,10 +1,6 @@
 <html layout:decorate="~{common/layout.html}">
 <head>
     <title>PLANBTI 테스트</title>
-<!--    <meta name="description" content="나에게 딱 맞는 식물을 MBTI를 기반으로 추천해주는 테스트">-->
-<!--    <meta property="og:type" content="website">-->
-<!--    <meta property="og:title" content="식물 유형 테스트">-->
-<!--    <meta property="og:description" content="나에게 딱 맞는 식물을 MBTI를 기반으로 추천해주는 테스트">-->
     <script src="https://code.jquery.com/jquery-3.5.1.js"></script>
 </head>
 

--- a/src/main/resources/templates/member/testResult.html
+++ b/src/main/resources/templates/member/testResult.html
@@ -13,6 +13,10 @@
         <div th:if="${!#lists.isEmpty(testresults)}" class="w-full h-full flex flex-col justify-center items-center">
 
         </div>
+        <div th:unless="${#lists.isEmpty(testresults)}">
+           <h1 class="text-2xl text-center" th:text="${testresults.title}"></h1>
+            <p class="mb-6" th:text="${testresults.content}"></p>
+        </div>
     </main>
 
 </body>

--- a/src/main/resources/templates/member/testResult.html
+++ b/src/main/resources/templates/member/testResult.html
@@ -6,17 +6,18 @@
 
 <body>
 
-    <main layout:fragment="main" class="w-screen h-full">
-        <div th:if="${#lists.isEmpty(testresults)}" class="w-full h-full flex justify-center items-center">
-            <p class="text-2xl">테스트 결과 내역이 존재하지 않습니다.</p>
+    <main layout:fragment="main" class="flex items-center justify-center container mx-auto min-h-screen max-w-2xl">
+        <div th:if="${#lists.isEmpty(tests)}">
+            <p>테스트 결과 내역이 존재하지 않습니다.</p>
         </div>
-        <div th:if="${!#lists.isEmpty(testresults)}" class="w-full h-full flex flex-col justify-center items-center">
+        <div th:unless="${#lists.isEmpty(tests)}">
+            <div th:each="test : ${tests}">
+                <h2 class="text-2xl text-center py-12" th:text="${test.title}"></h2>
+                <p class="mb-2" th:text="${test.content}"></p>
+            </div>
+        </div>
 
-        </div>
-        <div th:unless="${#lists.isEmpty(testresults)}">
-           <h1 class="text-2xl text-center" th:text="${testresults.title}"></h1>
-            <p class="mb-6" th:text="${testresults.content}"></p>
-        </div>
+
     </main>
 
 </body>


### PR DESCRIPTION
## 쿠키(MbtiTestController)
- 쿠키 저장 로직 만들 때 간소하게 만들어서 추가로 쿠키를 mbti 유형, 식물 이름, 설명 3가지를 저장
- 저장해야 하는 문자열을 인코딩하여 저장
## MbtiTest 엔티티
- 쿠키 값의 맞춰서 쿠키 값 받는 3개와 로그인 회원 검증을 위한 memberUsername 1개 추가
## MemberController
#### /testresult
-  /testresult 접속하면 쿠키를 DB에 저장하고 지금 유저의 DB에서 불러와서 출력
- 현재는 유저가 여러 번 테스트를 했을 때 결과가 다르면 저장해서 페이지에서 모두 보여준다
## TestSevice
#### createTestResult
- 인코딩된 쿠키를 디코딩 후 중복체크 후에 저장